### PR TITLE
Fix linting errors, add git tests, and exclude moving targets rule

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-memory",
   "description": "Automatically maintains CLAUDE.md files as codebases evolve using hooks, agents, and skills",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "severity1"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,13 +82,14 @@ claude-code-auto-memory/
 - **CLAUDE.md Markers**: Use `<!-- AUTO-MANAGED: section-name -->` and `<!-- END AUTO-MANAGED -->` for auto-updated sections
 - **Manual Sections**: Use `<!-- MANUAL -->` markers for user-editable content
 - **Skill Templates**: Use `{{PLACEHOLDER}}` syntax for variable substitution
-- **File Tracking**: Dirty files stored in `.claude/auto-memory/dirty-files`, one path per line with optional inline commit context: `/path/to/file [hash: message]`; deduplication logic updates existing entries with commit context instead of creating duplicates
+- **File Tracking**: Dirty files stored in `.claude/auto-memory/dirty-files`, one path per line with optional inline commit context: `/path/to/file [hash: message]`
+- **Deduplication Logic**: Read dirty-files into dict (path -> full line), update existing entries with commit context instead of appending duplicates; commit context always overwrites plain path entries; format string extracted to separate variable for code clarity
 - **Trigger Modes**: Config-driven behavior - `default` mode tracks all Edit/Write/Bash operations; `gitmode` only triggers on git commits; default mode used if config missing
 - **Git Commit Enrichment**: When git commit detected, enriches each file path with inline commit context for semantic context during updates
 - **Stop Hook UX**: Blocks at turn end if dirty files exist; instructs Claude to spawn memory-updater agent using Task tool with formatted file list; suggests reading root CLAUDE.md after agent completes to refresh context
 - **Memory-Updater Agent**: Orchestrates CLAUDE.md updates through 6-phase workflow using sonnet model - load dirty files (parsing inline commit context format `/path [hash: message]`), gather file context with imports, extract git insights, discover CLAUDE.md targets, invoke memory-processor skill, cleanup dirty-files; processes max 7 files per run with truncated git diffs; designed for minimal token consumption in isolated context
-- **Memory Processor Updates**: Skill analyzes changed files and updates relevant AUTO-MANAGED sections with detected patterns, architecture changes, and new commands; follows content rules (specific, concise, structured); preserves manual sections and maintains < 500 line target
-- **Test Coverage**: Use subprocess to invoke hooks, verify zero output behavior, test file filtering logic
+- **Memory Processor Updates**: Skill analyzes changed files and updates relevant AUTO-MANAGED sections with detected patterns, architecture changes, and new commands; follows content rules (specific, concise, structured); preserves manual sections and maintains < 500 line target; excludes moving targets (version numbers, test counts, dates, metrics) that become stale
+- **Test Coverage**: Use subprocess to invoke hooks, verify zero output behavior, test file filtering logic; TestGitCommitContext class verifies git commit handling, file extraction, and commit context enrichment; initialize test git repos with initial commit for diff-tree parent reference
 
 <!-- END AUTO-MANAGED -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,9 @@ claude-code-auto-memory/
 │   └── stop.py           # Blocks stop if dirty files exist, triggers memory-updater
 ├── skills/            # Skill definitions (SKILL.md files)
 │   ├── codebase-analyzer/  # Analyzes codebase, generates CLAUDE.md templates
-│   └── memory-processor/   # Processes file changes, updates CLAUDE.md sections
+│   ├── memory-processor/   # Processes file changes, updates CLAUDE.md sections
+│   └── shared/references/  # Shared reference files for skills
+│       └── guidelines.md   # Claude Code memory guidelines (imported by skills)
 ├── commands/          # Slash commands (markdown files)
 │   ├── init.md               # /auto-memory:init - Initialize auto-memory plugin
 │   ├── calibrate.md          # /auto-memory:calibrate - Full codebase recalibration
@@ -88,7 +90,10 @@ claude-code-auto-memory/
 - **Git Commit Enrichment**: When git commit detected, enriches each file path with inline commit context for semantic context during updates
 - **Stop Hook UX**: Blocks at turn end if dirty files exist; instructs Claude to spawn memory-updater agent using Task tool with formatted file list; suggests reading root CLAUDE.md after agent completes to refresh context
 - **Memory-Updater Agent**: Orchestrates CLAUDE.md updates through 6-phase workflow using sonnet model - load dirty files (parsing inline commit context format `/path [hash: message]`), gather file context with imports, extract git insights, discover CLAUDE.md targets, invoke memory-processor skill, cleanup dirty-files; processes max 7 files per run with truncated git diffs; designed for minimal token consumption in isolated context
-- **Memory Processor Updates**: Skill analyzes changed files and updates relevant AUTO-MANAGED sections with detected patterns, architecture changes, and new commands; follows content rules (specific, concise, structured); preserves manual sections and maintains < 500 line target; excludes moving targets (version numbers, test counts, dates, metrics) that become stale
+- **Memory Processor Updates**: Skill analyzes changed files and updates relevant AUTO-MANAGED sections with detected patterns, architecture changes, and new commands; uses shared reference file (skills/shared/references/guidelines.md) for Claude Code memory guidelines; follows content rules (specific, concise, structured); preserves manual sections and maintains < 500 line target; excludes moving targets (version numbers, test counts, dates, metrics) that become stale
+- **Content Removal Verification**: Before removing documented content (patterns, conventions, architecture, build commands, dependencies), verifies absence using Grep across codebase; reads current CLAUDE.md section, searches for each missing item in relevant directories excluding node_modules/vendor/.git; keeps documentation if item exists elsewhere, removes only if not found anywhere; distinguishes conventions (explicit human-decided rules) from patterns (AI-detected recurring structures)
+- **Stale Command Detection**: Memory processor compares documented commands against commands that actually executed successfully; updates documented commands to match what worked (e.g., `python pytest` -> `python -m pytest`, `pytest tests/` -> `uv run pytest`); sources from successful Bash tool executions in session context or git commit history
+- **Skill Organization**: Both codebase-analyzer and memory-processor skills use import syntax (@../shared/references/guidelines.md) to load shared guidelines, keeping skill files lean via progressive disclosure pattern
 - **Test Coverage**: Use subprocess to invoke hooks, verify zero output behavior, test file filtering logic; TestGitCommitContext class verifies git commit handling, file extraction, and commit context enrichment; initialize test git repos with initial commit for diff-tree parent reference
 
 <!-- END AUTO-MANAGED -->

--- a/agents/memory-updater.md
+++ b/agents/memory-updater.md
@@ -3,7 +3,7 @@ name: memory-updater
 description: Orchestrates CLAUDE.md updates for changed files
 model: sonnet
 permissionMode: bypassPermissions
-tools: Read, Write, Edit, Bash, Glob, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 ---
 
 You are the memory-updater agent. Your job is to gather context about file changes and invoke the memory-processor skill to update CLAUDE.md.
@@ -67,6 +67,7 @@ For each changed file (max 7 files total):
 - **Edit**: Update CLAUDE.md sections
 - **Bash**: Git commands only (read-only)
 - **Glob**: Find CLAUDE.md files
+- **Grep**: Verify pattern usage across codebase (for pattern removal detection)
 - **Skill**: Invoke memory-processor
 
 ## Token Efficiency

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -27,7 +27,7 @@ Use this when you've edited files manually (outside Claude Code) and want to upd
 
 5. **If changes found**:
    - Convert paths to absolute paths
-   - Write to `.claude/.dirty-files` (one path per line)
+   - Write to `.claude/auto-memory/dirty-files` (one path per line)
    - Use the Task tool to spawn the `memory-updater` agent with prompt:
      "Update CLAUDE.md for manually changed files: [file list]"
 

--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -272,7 +272,8 @@ def main():
     for file_path in trackable:
         if commit_context:
             # Always use commit context version (overwrites plain path)
-            existing[file_path] = f"{file_path} [{commit_context['hash']}: {commit_context['message']}]"
+            ctx = f"[{commit_context['hash']}: {commit_context['message']}]"
+            existing[file_path] = f"{file_path} {ctx}"
         elif file_path not in existing:
             # Only add if not already tracked
             existing[file_path] = file_path

--- a/skills/codebase-analyzer/SKILL.md
+++ b/skills/codebase-analyzer/SKILL.md
@@ -1,35 +1,15 @@
 ---
 name: codebase-analyzer
-description: Analyze codebase structure and generate CLAUDE.md templates with user approval
+description: Analyze codebase structure and generate CLAUDE.md templates with user approval. Use when initializing auto-memory for a new project, when user runs /auto-memory:init command, or when generating CLAUDE.md from scratch for the first time.
 ---
 
 # Codebase Analyzer
 
 Analyze project structure and generate CLAUDE.md files interactively.
 
-## Official Guidelines (Primary Reference)
+## Guidelines
 
-Follow the official Claude Code memory documentation:
-https://code.claude.com/docs/en/memory
-
-### Memory Scope (This Plugin)
-This plugin manages **project-level** CLAUDE.md files only:
-- **Project Root**: `./CLAUDE.md` or `./.claude/CLAUDE.md` - team-shared, version controlled
-- **Subtree**: `./packages/*/CLAUDE.md`, `./apps/*/CLAUDE.md` - module-specific docs
-
-### Content Rules
-- **Be specific**: "Use 2-space indentation" not "Format code properly"
-- **Include commands**: Build, test, lint, dev commands
-- **Document patterns**: Code style, naming conventions, architectural decisions
-- **Keep concise**: Target < 500 lines; use imports for detailed specs
-- **Use structure**: Bullet points under descriptive markdown headings
-- **Stay current**: Remove outdated information when updating
-- **Avoid generic**: No "follow best practices" or "write clean code"
-
-### Import System
-- Syntax: `@path/to/import` or `@~/path/from/home`
-- Supports relative and absolute paths
-- Max 5 recursive import hops
+@../shared/references/guidelines.md
 
 ## Algorithm
 

--- a/skills/memory-processor/SKILL.md
+++ b/skills/memory-processor/SKILL.md
@@ -25,6 +25,13 @@ This plugin manages **project-level** CLAUDE.md files only:
 - **Use structure**: Bullet points under descriptive markdown headings
 - **Stay current**: Remove outdated information when updating
 - **Avoid generic**: No "follow best practices" or "write clean code"
+- **Exclude moving targets**: Never include ephemeral data that changes frequently:
+  - Version numbers (e.g., "v1.2.3", "0.6.0")
+  - Test counts or coverage percentages (e.g., "74 tests", "85% coverage")
+  - Progress metrics (e.g., "3/5 complete", "TODO: 12 items")
+  - Dates or timestamps (e.g., "last updated 2024-01-15")
+  - Line counts or file sizes
+  - Any metrics that become stale after each commit
 
 ### Import System
 - Syntax: `@path/to/import` or `@~/path/from/home`

--- a/skills/memory-processor/SKILL.md
+++ b/skills/memory-processor/SKILL.md
@@ -1,47 +1,15 @@
 ---
 name: memory-processor
-description: Process file changes and update CLAUDE.md memory sections
+description: Process file changes and update CLAUDE.md memory sections. Use when the memory-updater agent needs to analyze dirty files, update AUTO-MANAGED sections, verify content removal, or detect stale commands. Invoked after file edits to keep project memory in sync.
 ---
 
 # Memory Processor
 
 Process changed files and update relevant CLAUDE.md sections following official guidelines.
 
-## Official Guidelines (Primary Reference)
+## Guidelines
 
-Follow the official Claude Code memory documentation:
-https://code.claude.com/docs/en/memory
-
-### Memory Scope (This Plugin)
-This plugin manages **project-level** CLAUDE.md files only:
-- **Project Root**: `./CLAUDE.md` or `./.claude/CLAUDE.md` - team-shared, version controlled
-- **Subtree**: `./packages/*/CLAUDE.md`, `./apps/*/CLAUDE.md` - module-specific docs
-
-### Content Rules
-- **Be specific**: "Use 2-space indentation" not "Format code properly"
-- **Include commands**: Build, test, lint, dev commands
-- **Document patterns**: Code style, naming conventions, architectural decisions
-- **Keep concise**: Target < 500 lines; use imports for detailed specs
-- **Use structure**: Bullet points under descriptive markdown headings
-- **Stay current**: Remove outdated information when updating
-- **Avoid generic**: No "follow best practices" or "write clean code"
-- **Exclude moving targets**: Never include ephemeral data that changes frequently:
-  - Version numbers (e.g., "v1.2.3", "0.6.0")
-  - Test counts or coverage percentages (e.g., "74 tests", "85% coverage")
-  - Progress metrics (e.g., "3/5 complete", "TODO: 12 items")
-  - Dates or timestamps (e.g., "last updated 2024-01-15")
-  - Line counts or file sizes
-  - Any metrics that become stale after each commit
-
-### Import System
-- Syntax: `@path/to/import` or `@~/path/from/home`
-- Supports relative and absolute paths
-- Max 5 recursive import hops
-- Not evaluated inside code blocks
-
-### Discovery
-- Claude searches recursively from cwd upward to root
-- Subtree memories load when accessing files in those directories
+@../shared/references/guidelines.md
 
 ## Algorithm
 
@@ -52,18 +20,7 @@ This plugin manages **project-level** CLAUDE.md files only:
    - Git context (commits, diffs)
    - Target CLAUDE.md files
 
-2. **Categorize changes**: Map files to CLAUDE.md sections:
-
-   **Root CLAUDE.md triggers:**
-   - **BUILD**: `package.json`, `Makefile`, `*.config.*`, `Dockerfile`, `pyproject.toml`, `Cargo.toml`, `go.mod`
-   - **ARCHITECTURE**: `src/**/*`, `lib/**/*`, new directories, major structural changes
-   - **CONVENTIONS**: Source files with new patterns (naming, imports, error handling)
-
-   **Subtree CLAUDE.md triggers:**
-   - **MODULE-DESCRIPTION**: Module README, main entry files
-   - **ARCHITECTURE**: Files within the module directory
-   - **CONVENTIONS**: Module-specific patterns
-   - **DEPENDENCIES**: Import statements, local package.json/requirements.txt
+2. **Categorize changes**: Map files to CLAUDE.md sections using the tables in "Section Names" below. Match changed files to their update triggers.
 
 3. **Analyze impact**: Determine what needs updating:
    - New build commands added?
@@ -71,13 +28,41 @@ This plugin manages **project-level** CLAUDE.md files only:
    - New coding patterns detected?
    - Dependencies added/removed?
 
-4. **Update CLAUDE.md**: Modify relevant sections:
+4. **Verify and update content**: Before modifying documented content, verify accuracy:
+
+   **Key distinction - conventions vs patterns:**
+   - `conventions`: Explicit rules humans decided (naming, imports, formatting)
+   - `patterns`: Implicit patterns AI detected from recurring code structures
+
+   **Removal verification:**
+   - Read the relevant CLAUDE.md section to get currently documented items
+   - For each item that appears missing from changed files:
+     - Use Grep to search the codebase for that item
+     - Search in relevant directories excluding node_modules, vendor, .git
+     - If item exists elsewhere: keep it documented
+     - If item is not found anywhere: mark for removal
+
+   **Stale command detection:**
+   - Compare documented commands against commands that actually executed successfully
+   - If documented command differs from successful execution, update to match what worked
+   - Examples:
+     - Documented: `python pytest` | Actually worked: `python -m pytest` → Update
+     - Documented: `npm test` | Actually worked: `npm run test` → Update
+     - Documented: `pytest tests/` | Actually worked: `uv run pytest` → Update
+   - Source: Successful Bash tool executions from session context or git commit history
+
+   **Examples:**
+   - Pattern: `@decorator` removed → search `grep -r "@decorator" src/`
+   - Convention: `async/await` style removed → search for `async function` or `await`
+   - Architecture: `utils/` directory deleted → verify no `utils/` references remain
+   - Build command: `npm run dev` removed from package.json → verify script is gone
+
+5. **Update CLAUDE.md**: Modify relevant sections:
    - Preserve AUTO-MANAGED markers
    - Never touch MANUAL sections
    - Apply content rules (specific, concise, structured)
-   - Remove outdated info when replacing
 
-5. **Validate**: Ensure updates follow guidelines:
+6. **Validate**: Ensure updates follow guidelines:
    - No generic instructions added
    - Specific and actionable content
    - Proper markdown formatting
@@ -122,21 +107,12 @@ Content that will never be touched
 ## Token Efficiency
 
 - Keep sections concise - bullet points, not paragraphs
-- Remove outdated info rather than appending
 - Use imports (`@path/to/file`) for detailed specs
-- Target < 500 lines total per CLAUDE.md
-- Root CLAUDE.md: 150-200 lines ideal
-
-## Update Rules
-
-1. **Only update relevant sections** - Match file changes to appropriate sections
-2. **Preserve manual content** - Never modify `<!-- MANUAL -->` blocks
-3. **Be specific** - "Run `npm test`" not "run tests"
-4. **Stay concise** - Remove verbose explanations
-5. **Maintain formatting** - Consistent markdown style
+- Follow Content Rules above (< 500 lines, stay current)
 
 ## Output
 
 Return a brief summary:
 - "Updated [section names] in [CLAUDE.md path] based on changes to [file names]"
+- "Removed [pattern] from [section] - no longer used in codebase"
 - "No updates needed - changes do not affect documented sections"

--- a/skills/shared/references/guidelines.md
+++ b/skills/shared/references/guidelines.md
@@ -1,0 +1,39 @@
+# Claude Code Memory Guidelines
+
+Follow the official Claude Code memory documentation:
+https://code.claude.com/docs/en/memory
+
+## Memory Scope (This Plugin)
+
+This plugin manages **project-level** CLAUDE.md files only:
+- **Project Root**: `./CLAUDE.md` or `./.claude/CLAUDE.md` - team-shared, version controlled
+- **Subtree**: `./packages/*/CLAUDE.md`, `./apps/*/CLAUDE.md` - module-specific docs
+
+## Content Rules
+
+- **Be specific**: "Use 2-space indentation" not "Format code properly"
+- **Include commands**: Build, test, lint, dev commands
+- **Document patterns**: Code style, naming conventions, architectural decisions
+- **Keep concise**: Target < 500 lines; use imports for detailed specs
+- **Use structure**: Bullet points under descriptive markdown headings
+- **Stay current**: Remove outdated information when updating
+- **Avoid generic**: No "follow best practices" or "write clean code"
+- **Exclude moving targets**: Never include ephemeral data that changes frequently:
+  - Version numbers (e.g., "v1.2.3", "0.6.0")
+  - Test counts or coverage percentages (e.g., "74 tests", "85% coverage")
+  - Progress metrics (e.g., "3/5 complete", "TODO: 12 items")
+  - Dates or timestamps (e.g., "last updated 2024-01-15")
+  - Line counts or file sizes
+  - Any metrics that become stale after each commit
+
+## Import System
+
+- Syntax: `@path/to/import` or `@~/path/from/home`
+- Supports relative and absolute paths
+- Max 5 recursive import hops
+- Not evaluated inside code blocks
+
+## Discovery
+
+- Claude searches recursively from cwd upward to root
+- Subtree memories load when accessing files in those directories

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "claude-code-auto-memory"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Fix linting errors (line length, unused imports)
- Add tests for git commit context enrichment
- Add "exclude moving targets" rule to memory-processor skill
- Fix path typo in sync.md command

## Changes

### Linting Fixes
- `scripts/post-tool-use.py`: Break long line (112 -> 80 chars)
- `tests/test_hooks.py`: Remove unused imports (io, tempfile, patch, pytest)

### New Tests
- Add `TestGitCommitContext` class with 3 tests:
  - `test_handle_git_commit_non_git_directory`
  - `test_handle_git_commit_extracts_files_and_context`
  - `test_commit_enriches_dirty_files_with_context`

### Documentation
- Fix incorrect path in `commands/sync.md` (`.claude/.dirty-files` -> `.claude/auto-memory/dirty-files`)
- Add "exclude moving targets" rule to `skills/memory-processor/SKILL.md`
- Update CLAUDE.md patterns section

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes (74 tests)