### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # claude-code-auto-memory
 
+[![Run in Smithery](https://smithery.ai/badge/skills/severity1)](https://smithery.ai/skills?ns=severity1&utm_source=github&utm_medium=badge)
+
+
 **Your CLAUDE.md, always in sync.** Minimal tokens. Zero config. Just works.
 
 A Claude Code plugin that watches what Claude Code edits, deletes, and moves - then quietly updates your project memory in the background. No manual maintenance needed.


### PR DESCRIPTION
## Add skill discoverability badge

Your 3 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/severity1)](https://smithery.ai/skills?ns=severity1&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.