### PR TITLE
Fix git commits re-populating dirty-files in default mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ Recent design decisions from commit history:
 - Template enforcement added to ensure consistent CLAUDE.md structure
 - Git commit context enrichment for better change tracking
 - Configurable trigger modes (default vs gitmode)
+- Windows compatibility: python3/python fallback pattern in hook commands
+- Default mode optimization: Skip git commit tracking (files already tracked via Edit/Write)
 
 <!-- END AUTO-MANAGED -->
 

--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -9,8 +9,8 @@ Supports configurable trigger modes:
 - default: Track Edit/Write/Bash operations (current behavior)
 - gitmode: Only track git commits
 
-When a git commit is detected, enriches each file path with inline commit
-context: /path/to/file [hash: commit message]
+In gitmode, when a git commit is detected, enriches each file path with
+inline commit context: /path/to/file [hash: commit message]
 """
 
 from __future__ import annotations
@@ -260,6 +260,10 @@ def main():
 
     # In gitmode, only process git commits
     if trigger_mode == "gitmode" and not is_git_commit:
+        return
+
+    # In default mode, skip git commits (files already tracked via Edit/Write hooks)
+    if trigger_mode == "default" and is_git_commit:
         return
 
     files_to_track = []

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -336,6 +336,19 @@ class TestPostToolUseHook:
         assert "deleted.py" in content
         assert "/dev/null" not in content
 
+    def test_skip_git_commit_in_default_mode(self, tmp_path):
+        """Hook skips git commit commands in default mode (files tracked via Edit/Write)."""
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
+            env={**os.environ, **env},
+            input=self._make_bash_input("git commit -m 'Add feature'"),
+            capture_output=True,
+            text=True,
+        )
+        dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        assert not dirty_file.exists()
+
 
 class TestStopHook:
     """Tests for trigger.py Stop hook behavior."""
@@ -753,9 +766,14 @@ class TestGitCommitContext:
         sys.modules.pop("post-tool-use", None)
 
     def test_commit_enriches_dirty_files_with_context(self, tmp_path):
-        """Git commit command enriches dirty files with inline context."""
+        """Git commit command enriches dirty files with inline context in gitmode."""
         # Initialize git repo
         self._init_git_repo(tmp_path)
+
+        # Set up gitmode config (commit enrichment only applies in gitmode)
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "gitmode"}))
 
         # Create and commit a file
         test_file = tmp_path / "module.py"
@@ -778,7 +796,7 @@ class TestGitCommitContext:
         )
 
         # Check dirty files contain commit context
-        dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        dirty_file = config_dir / "dirty-files"
         assert dirty_file.exists()
         content = dirty_file.read_text()
 


### PR DESCRIPTION
## Summary

- In default mode, git commit commands no longer re-populate dirty-files after the memory-updater has already processed them. Previously, PostToolUse would detect `git commit` in the Bash command, call `handle_git_commit()`, and re-add committed files - causing the Stop hook to fire again for already-processed files.
- Added symmetric early-return guard in `post-tool-use.py`: default mode skips git commits (files already tracked via Edit/Write), just as gitmode skips non-commit operations.
- Fixed `test_commit_enriches_dirty_files_with_context` to run in gitmode where commit context enrichment actually applies.

## Test plan

- [x] All 123 tests pass (`uv run pytest tests/ -v`)
- [x] New `test_skip_git_commit_in_default_mode` verifies git commit commands do not populate dirty-files in default mode
- [x] Existing `test_commit_enriches_dirty_files_with_context` updated to use gitmode config