### PR TITLE
Fix #17/#25/#26: skip hooks on uninitialized projects, SubagentStop cleanup, Windows path quoting, type annotations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-memory",
   "description": "Automatically maintains CLAUDE.md files as codebases evolve using hooks, agents, and skills",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "severity1"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,8 @@ Configuration:
 ## Detected Patterns
 
 - **Hook Consolidation Pattern**: Single trigger.py handles PreToolUse, Stop, and SubagentStop hooks, routing based on hook_event_name
-- **Hook Lifecycle Pattern**: PostToolUse tracks → Stop/PreToolUse blocks → Agent spawns → SubagentStop cleans up
+- **Initialization Guard Pattern**: `plugin_initialized()` in post-tool-use.py, handle_stop(), and handle_pre_tool_use() gates all activity on config.json existence — projects that never ran /auto-memory:init are fully inert
+- **Hook Lifecycle Pattern**: PostToolUse tracks → Stop/PreToolUse blocks → Agent spawns → SubagentStop cleans up (cleanup gated on dirty-files only, not config.json, to prevent infinite loops)
 - **Separation of Concerns**: PostToolUse (silent tracking) vs Stop/PreToolUse (blocking with output) vs SubagentStop (cleanup)
 - **Dirty File Pattern**: Append-only tracking, batch processing at turn end
 - **Skill Pattern**: YAML frontmatter + markdown body with algorithm sections
@@ -125,6 +126,9 @@ Recent design decisions from commit history:
 - Configurable trigger modes (default vs gitmode)
 - Windows compatibility: python3/python fallback pattern in hook commands
 - Default mode optimization: Skip git commit tracking (files already tracked via Edit/Write)
+- SubagentStop cleanup gated on dirty-files only (not config.json): requiring config.json caused infinite Stop-hook loops on uninitialized projects where dirty-files never got cleared
+- Initialization guard added (#17): plugin_initialized() check in PostToolUse, Stop, and PreToolUse keeps the plugin fully inert on projects that never ran /auto-memory:init
+- Type annotations tightened: dict[str, Any] generics, typed main() -> None, narrowed handle_git_commit return type
 
 <!-- END AUTO-MANAGED -->
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py"
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-use.py\"",
             "timeout": 10
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py\"",
             "timeout": 5
           }
         ]
@@ -36,11 +36,11 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "memory-updater",
+        "matcher": "(auto-memory:)?memory-updater$",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/trigger.py\"",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-code-auto-memory"
-version = "0.8.2"
+version = "0.8.3"
 description = "Automatically maintains CLAUDE.md files as codebases evolve"
 readme = "README.md"
 license = "MIT"

--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -23,6 +23,19 @@ import sys
 from pathlib import Path
 
 
+def plugin_initialized(project_dir: str) -> bool:
+    """Return True if the plugin has been initialized for this project.
+
+    The presence of .claude/auto-memory/config.json is the explicit
+    opt-in marker - users create it by running /auto-memory:init. On
+    projects without config.json we keep the plugin entirely inert:
+    PostToolUse does not track any file edits, so dirty-files never
+    gets created and the downstream Stop hook never spawns memory-updater
+    (#17).
+    """
+    return (Path(project_dir) / ".claude" / "auto-memory" / "config.json").exists()
+
+
 def load_config(project_dir: str) -> dict:
     """Load plugin configuration from .claude/auto-memory/config.json."""
     config_file = Path(project_dir) / ".claude" / "auto-memory" / "config.json"
@@ -235,6 +248,10 @@ def main():
     # CLAUDE_PROJECT_DIR is required - don't use cwd fallback as it may be wrong
     # (e.g., plugin cache directory instead of user's project)
     if not project_dir:
+        return
+
+    # Skip entirely on projects where the user hasn't run /auto-memory:init
+    if not plugin_initialized(project_dir):
         return
 
     # Read tool input from stdin (JSON format)

--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -21,21 +21,23 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
-def load_config(project_dir: str) -> dict:
+def load_config(project_dir: str) -> dict[str, Any]:
     """Load plugin configuration from .claude/auto-memory/config.json."""
     config_file = Path(project_dir) / ".claude" / "auto-memory" / "config.json"
     if config_file.exists():
         try:
             with open(config_file) as f:
-                return json.load(f)
+                data: dict[str, Any] = json.load(f)
+                return data
         except (json.JSONDecodeError, OSError):
             pass
     return {"triggerMode": "default"}
 
 
-def handle_git_commit(project_dir: str) -> tuple[list[str], dict | None]:
+def handle_git_commit(project_dir: str) -> tuple[list[str], dict[str, str] | None]:
     """Extract context from a git commit.
 
     Returns: (files, commit_context) where commit_context is {"hash": ..., "message": ...}
@@ -229,7 +231,7 @@ def extract_files_from_bash(command: str, project_dir: str) -> list[str]:
     return resolved
 
 
-def main():
+def main() -> None:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
 
     # CLAUDE_PROJECT_DIR is required - don't use cwd fallback as it may be wrong
@@ -238,6 +240,7 @@ def main():
         return
 
     # Read tool input from stdin (JSON format)
+    tool_input: dict[str, Any]
     try:
         stdin_data = sys.stdin.read()
         tool_input = json.loads(stdin_data) if stdin_data else {}

--- a/scripts/trigger.py
+++ b/scripts/trigger.py
@@ -19,6 +19,19 @@ import sys
 from pathlib import Path
 
 
+def plugin_initialized(project_dir: str) -> bool:
+    """Return True if the plugin has been initialized for this project.
+
+    The presence of .claude/auto-memory/config.json is the explicit
+    opt-in marker - users create it by running /auto-memory:init. On
+    projects without config.json we keep the plugin entirely inert:
+    no Stop-hook blocking, no PreToolUse interception, no memory-updater
+    agent spawn. This prevents auto-memory from intruding on projects
+    where the user never opted in (#17).
+    """
+    return (Path(project_dir) / ".claude" / "auto-memory" / "config.json").exists()
+
+
 def load_config(project_dir: str) -> dict:
     """Load plugin configuration from .claude/auto-memory/config.json."""
     config_file = Path(project_dir) / ".claude" / "auto-memory" / "config.json"
@@ -73,6 +86,10 @@ def handle_stop(input_data: dict, project_dir: str) -> None:
     if input_data.get("stop_hook_active", False):
         return
 
+    # Skip entirely on projects where the user hasn't run /auto-memory:init
+    if not plugin_initialized(project_dir):
+        return
+
     config = load_config(project_dir)
     trigger_mode = config.get("triggerMode", "default")
 
@@ -124,6 +141,10 @@ def handle_pre_tool_use(input_data: dict, project_dir: str) -> None:
     Only active in gitmode. Denies git commit commands when dirty files
     exist, forcing the memory-updater to run first.
     """
+    # Skip entirely on projects where the user hasn't run /auto-memory:init
+    if not plugin_initialized(project_dir):
+        return
+
     config = load_config(project_dir)
     trigger_mode = config.get("triggerMode", "default")
 

--- a/scripts/trigger.py
+++ b/scripts/trigger.py
@@ -105,14 +105,12 @@ def clear_dirty_files(project_dir: str) -> None:
 def handle_subagent_stop(project_dir: str) -> None:
     """Handle SubagentStop hook event.
 
-    Clears dirty-files after the memory-updater agent completes. Scoped to
-    our plugin by checking that both config.json exists (plugin active) and
-    dirty-files is non-empty (there's something to clean up).
+    Clears dirty-files after the memory-updater agent completes. Gated on
+    dirty-files presence alone - we intentionally do not require
+    config.json to exist, because doing so caused an infinite Stop-hook
+    loop on uninitialized projects (#17, #25): the Stop hook would
+    re-fire every turn on stale dirty-files that never got cleared.
     """
-    config_file = Path(project_dir) / ".claude" / "auto-memory" / "config.json"
-    if not config_file.exists():
-        return
-
     files = read_dirty_files(project_dir)
     if not files:
         return

--- a/scripts/trigger.py
+++ b/scripts/trigger.py
@@ -17,15 +17,17 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 
-def load_config(project_dir: str) -> dict:
+def load_config(project_dir: str) -> dict[str, Any]:
     """Load plugin configuration from .claude/auto-memory/config.json."""
     config_file = Path(project_dir) / ".claude" / "auto-memory" / "config.json"
     if config_file.exists():
         try:
             with open(config_file) as f:
-                return json.load(f)
+                data: dict[str, Any] = json.load(f)
+                return data
         except (json.JSONDecodeError, OSError):
             pass
     return {"triggerMode": "default"}
@@ -67,7 +69,7 @@ def build_spawn_reason(files: list[str]) -> str:
     )
 
 
-def handle_stop(input_data: dict, project_dir: str) -> None:
+def handle_stop(input_data: dict[str, Any], project_dir: str) -> None:
     """Handle Stop hook event."""
     # Prevent infinite loop when stop_hook_active is set
     if input_data.get("stop_hook_active", False):
@@ -120,7 +122,7 @@ def handle_subagent_stop(project_dir: str) -> None:
     clear_dirty_files(project_dir)
 
 
-def handle_pre_tool_use(input_data: dict, project_dir: str) -> None:
+def handle_pre_tool_use(input_data: dict[str, Any], project_dir: str) -> None:
     """Handle PreToolUse hook event.
 
     Only active in gitmode. Denies git commit commands when dirty files
@@ -160,12 +162,13 @@ def handle_pre_tool_use(input_data: dict, project_dir: str) -> None:
     print(json.dumps(output))
 
 
-def main():
+def main() -> None:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
     if not project_dir:
         return
 
     # Read stdin JSON to determine which hook event fired
+    input_data: dict[str, Any]
     try:
         input_data = json.loads(sys.stdin.read())
     except json.JSONDecodeError:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,6 +13,12 @@ SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 class TestPostToolUseHook:
     """Tests for post-tool-use.py hook."""
 
+    def _init_config(self, tmp_path):
+        """Create config.json so plugin_initialized() returns True."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+
     def _make_tool_input(self, file_path: str, tool_name: str = "Edit") -> str:
         """Create JSON input for post-tool-use hook (Edit/Write tools)."""
         return json.dumps(
@@ -33,6 +39,7 @@ class TestPostToolUseHook:
 
     def test_creates_dirty_file(self, tmp_path):
         """Hook creates .claude/auto-memory/dirty-files if it doesn't exist."""
+        self._init_config(tmp_path)
         file_path = str(tmp_path / "file.py")
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         result = subprocess.run(
@@ -48,8 +55,9 @@ class TestPostToolUseHook:
 
     def test_appends_paths(self, tmp_path):
         """Hook appends file paths to dirty file."""
+        self._init_config(tmp_path)
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty_file.parent.mkdir(parents=True)
+        dirty_file.parent.mkdir(parents=True, exist_ok=True)
         existing_file = str(tmp_path / "existing" / "file.py")
         dirty_file.write_text(existing_file + "\n")
 
@@ -137,6 +145,7 @@ class TestPostToolUseHook:
 
     def test_tracks_rm_command(self, tmp_path):
         """Hook tracks files from rm command."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -152,6 +161,7 @@ class TestPostToolUseHook:
 
     def test_tracks_rm_with_flags(self, tmp_path):
         """Hook tracks files from rm -rf command."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -167,6 +177,7 @@ class TestPostToolUseHook:
 
     def test_tracks_rm_multiple_files(self, tmp_path):
         """Hook tracks multiple files from rm command."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -184,6 +195,7 @@ class TestPostToolUseHook:
 
     def test_tracks_git_rm_command(self, tmp_path):
         """Hook tracks files from git rm command."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -199,6 +211,7 @@ class TestPostToolUseHook:
 
     def test_tracks_mv_source(self, tmp_path):
         """Hook tracks source file from mv command."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -216,6 +229,7 @@ class TestPostToolUseHook:
 
     def test_tracks_unlink_command(self, tmp_path):
         """Hook tracks files from unlink command."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -271,6 +285,7 @@ class TestPostToolUseHook:
 
     def test_stops_at_shell_operators(self, tmp_path):
         """Hook stops parsing at shell operators like && || ; |."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
 
         # Test && operator - should only track file.py, not 'echo' or 'done'
@@ -291,6 +306,7 @@ class TestPostToolUseHook:
 
     def test_stops_at_semicolon(self, tmp_path):
         """Hook stops parsing at semicolon operator."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -307,6 +323,7 @@ class TestPostToolUseHook:
 
     def test_stops_at_pipe(self, tmp_path):
         """Hook stops parsing at pipe operator."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -323,6 +340,7 @@ class TestPostToolUseHook:
 
     def test_stops_at_redirect(self, tmp_path):
         """Hook stops parsing at redirect operators."""
+        self._init_config(tmp_path)
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
             [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
@@ -349,9 +367,35 @@ class TestPostToolUseHook:
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
         assert not dirty_file.exists()
 
+    def test_no_dirty_files_when_config_absent(self, tmp_path):
+        """Hook does not write dirty-files when config.json is absent (#17).
+
+        Projects without config.json have not run /auto-memory:init.
+        The plugin must stay entirely inert on those projects.
+        """
+        file_path = str(tmp_path / "src" / "main.py")
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
+            env={**os.environ, **env},
+            input=self._make_tool_input(file_path),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+        dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        assert not dirty_file.exists()
+
 
 class TestStopHook:
     """Tests for trigger.py Stop hook behavior."""
+
+    def _init_config(self, tmp_path):
+        """Create config.json so plugin_initialized() returns True."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
 
     def test_passes_when_empty(self, tmp_path):
         """Hook passes through when no dirty files exist."""
@@ -385,8 +429,9 @@ class TestStopHook:
 
     def test_blocks_with_files(self, tmp_path):
         """Hook blocks and outputs JSON when dirty files exist."""
+        self._init_config(tmp_path)
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty_file.parent.mkdir(parents=True)
+        dirty_file.parent.mkdir(parents=True, exist_ok=True)
         dirty_file.write_text("/path/to/file.py\n")
 
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
@@ -404,8 +449,9 @@ class TestStopHook:
 
     def test_json_format(self, tmp_path):
         """Hook output is valid JSON with required fields."""
+        self._init_config(tmp_path)
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty_file.parent.mkdir(parents=True)
+        dirty_file.parent.mkdir(parents=True, exist_ok=True)
         dirty_file.write_text("/path/to/file.py\n")
 
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
@@ -422,8 +468,9 @@ class TestStopHook:
 
     def test_deduplicates_files(self, tmp_path):
         """Hook deduplicates file paths in output."""
+        self._init_config(tmp_path)
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty_file.parent.mkdir(parents=True)
+        dirty_file.parent.mkdir(parents=True, exist_ok=True)
         dirty_file.write_text("/file.py\n/file.py\n/file.py\n")
 
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
@@ -440,8 +487,9 @@ class TestStopHook:
 
     def test_limits_file_count(self, tmp_path):
         """Hook limits file list to 20 files max."""
+        self._init_config(tmp_path)
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty_file.parent.mkdir(parents=True)
+        dirty_file.parent.mkdir(parents=True, exist_ok=True)
         files = [f"/file{i}.py" for i in range(30)]
         dirty_file.write_text("\n".join(files) + "\n")
 
@@ -463,8 +511,9 @@ class TestStopHook:
 
     def test_handles_invalid_json_input(self, tmp_path):
         """Hook handles invalid JSON input gracefully."""
+        self._init_config(tmp_path)
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty_file.parent.mkdir(parents=True)
+        dirty_file.parent.mkdir(parents=True, exist_ok=True)
         dirty_file.write_text("/path/to/file.py\n")
 
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
@@ -482,8 +531,9 @@ class TestStopHook:
 
     def test_output_includes_task_params(self, tmp_path):
         """Stop output includes run_in_background and bypassPermissions instructions."""
+        self._init_config(tmp_path)
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty_file.parent.mkdir(parents=True)
+        dirty_file.parent.mkdir(parents=True, exist_ok=True)
         dirty_file.write_text("/path/to/file.py\n")
 
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
@@ -497,6 +547,27 @@ class TestStopHook:
         output = json.loads(result.stdout)
         assert "run_in_background" in output["reason"]
         assert "bypassPermissions" in output["reason"]
+
+    def test_no_output_when_config_absent(self, tmp_path):
+        """Stop hook produces no output when config.json is absent (#17).
+
+        Even if dirty-files somehow exists, an uninitialized project
+        (no config.json) must not trigger the memory-updater agent.
+        """
+        dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        dirty_file.parent.mkdir(parents=True)
+        dirty_file.write_text("/path/to/file.py\n")
+
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "trigger.py"],
+            env={**os.environ, **env},
+            input="{}",
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
 
 
 class TestPreToolUseHook:
@@ -606,6 +677,26 @@ class TestPreToolUseHook:
         reason = output["hookSpecificOutput"]["permissionDecisionReason"]
         assert "run_in_background" in reason
         assert "bypassPermissions" in reason
+
+    def test_no_output_when_config_absent(self, tmp_path):
+        """PreToolUse produces no output when config.json is absent (#17).
+
+        An uninitialized project must not have git commits intercepted.
+        """
+        dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        dirty_file.parent.mkdir(parents=True)
+        dirty_file.write_text("/path/to/file.py\n")
+
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "trigger.py"],
+            env={**os.environ, **env},
+            input=self._make_pre_tool_input("git commit -m 'test'"),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
 
 
 class TestSubagentStopHook:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -76,6 +76,7 @@ class TestPostToolUseHook:
 
     def test_no_output(self, tmp_path):
         """Hook produces no output (zero token cost)."""
+        self._init_config(tmp_path)
         file_path = str(tmp_path / "file.py")
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         result = subprocess.run(
@@ -101,6 +102,7 @@ class TestPostToolUseHook:
 
     def test_excludes_claude_directory(self, tmp_path):
         """Hook excludes files in .claude/ directory."""
+        self._init_config(tmp_path)
         file_path = str(tmp_path / ".claude" / "state.json")
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(
@@ -115,6 +117,7 @@ class TestPostToolUseHook:
 
     def test_excludes_claude_md(self, tmp_path):
         """Hook excludes CLAUDE.md files."""
+        self._init_config(tmp_path)
         file_path = str(tmp_path / "CLAUDE.md")
         env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
         subprocess.run(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -631,8 +631,12 @@ class TestSubagentStopHook:
         assert result.stdout == ""
         assert dirty_file.read_text() == ""
 
-    def test_noop_when_no_config(self, tmp_path):
-        """Does nothing when config.json is missing (plugin not active)."""
+    def test_clears_dirty_files_even_without_config(self, tmp_path):
+        """Still clears dirty-files when config.json is missing (#17, #25).
+
+        Regression gate for the early-return guard that caused infinite
+        Stop-hook loops on uninitialized projects.
+        """
         dirty_dir = tmp_path / ".claude" / "auto-memory"
         dirty_dir.mkdir(parents=True)
         dirty_file = dirty_dir / "dirty-files"
@@ -648,8 +652,7 @@ class TestSubagentStopHook:
         )
         assert result.returncode == 0
         assert result.stdout == ""
-        # dirty-files should remain unchanged
-        assert dirty_file.read_text() == "/path/to/file.py\n"
+        assert dirty_file.read_text() == ""
 
     def test_noop_when_dirty_files_empty(self, tmp_path):
         """Does nothing when dirty-files is empty."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,9 +95,31 @@ class TestHooksConfiguration:
         assert "SubagentStop" in hooks_json["hooks"]
 
     def test_subagent_stop_matcher(self, hooks_json):
-        """SubagentStop hook has memory-updater matcher."""
+        """SubagentStop matcher catches both bare and plugin-qualified agent names.
+
+        The regex matches both `memory-updater` and
+        `auto-memory:memory-updater` so we're resilient to however
+        Claude Code resolves plugin-scoped subagent names at runtime (#25).
+        """
         subagent_stop = hooks_json["hooks"]["SubagentStop"][0]
-        assert subagent_stop["matcher"] == "memory-updater"
+        assert subagent_stop["matcher"] == "(auto-memory:)?memory-updater$"
+
+    def test_hook_commands_quote_plugin_root(self, hooks_json):
+        """All hook commands quote ${CLAUDE_PLUGIN_ROOT} for Windows paths with spaces (#26).
+
+        Unquoted `${CLAUDE_PLUGIN_ROOT}` breaks when the resolved path
+        contains whitespace (e.g. `C:\\Users\\First Last\\...`) because
+        the shell splits the path across multiple arguments.
+        """
+        for event_name, hook_list in hooks_json["hooks"].items():
+            for entry in hook_list:
+                for hook in entry["hooks"]:
+                    command = hook.get("command", "")
+                    if "${CLAUDE_PLUGIN_ROOT}" not in command:
+                        continue
+                    assert '"${CLAUDE_PLUGIN_ROOT}' in command, (
+                        f"{event_name} hook command has unquoted ${{CLAUDE_PLUGIN_ROOT}}: {command}"
+                    )
 
 
 class TestAgentConfiguration:

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -4,6 +4,7 @@ Tests internal functions directly (no subprocess), complementing the
 subprocess-based integration tests in test_hooks.py.
 """
 
+import importlib
 import json
 import sys
 from pathlib import Path
@@ -12,7 +13,6 @@ from unittest.mock import patch
 # Import trigger.py module
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
-import importlib
 
 trigger = importlib.import_module("trigger")
 sys.path.pop(0)
@@ -54,6 +54,30 @@ class TestLoadConfig:
 
         config = trigger.load_config(str(tmp_path))
         assert config["customField"] == "value"
+
+
+class TestPluginInitialized:
+    """Tests for plugin_initialized - opt-in guard for uninitialized projects (#17)."""
+
+    def test_returns_false_when_config_absent(self, tmp_path):
+        """Returns False when config.json does not exist."""
+        assert trigger.plugin_initialized(str(tmp_path)) is False
+
+    def test_returns_true_when_config_present(self, tmp_path):
+        """Returns True when config.json exists."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+
+        assert trigger.plugin_initialized(str(tmp_path)) is True
+
+    def test_returns_false_when_only_dirty_files_present(self, tmp_path):
+        """Returns False when dirty-files exists but config.json does not."""
+        dirty_dir = tmp_path / ".claude" / "auto-memory"
+        dirty_dir.mkdir(parents=True)
+        (dirty_dir / "dirty-files").write_text("/file.py\n")
+
+        assert trigger.plugin_initialized(str(tmp_path)) is False
 
 
 class TestReadDirtyFiles:
@@ -171,8 +195,10 @@ class TestHandleStop:
 
     def test_blocks_with_dirty_files(self, tmp_path, capsys):
         """Outputs block decision when dirty files exist."""
-        dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty.parent.mkdir(parents=True)
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+        dirty = config_dir / "dirty-files"
         dirty.write_text("/src/main.py\n")
 
         trigger.handle_stop({}, str(tmp_path))
@@ -190,6 +216,15 @@ class TestHandleStop:
         trigger.handle_stop({}, str(tmp_path))
         output = json.loads(capsys.readouterr().out)
         assert output["decision"] == "block"
+
+    def test_no_output_when_not_initialized(self, tmp_path, capsys):
+        """No output when config.json is absent, even with dirty files (#17)."""
+        dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        dirty.parent.mkdir(parents=True)
+        dirty.write_text("/src/main.py\n")
+
+        trigger.handle_stop({}, str(tmp_path))
+        assert capsys.readouterr().out == ""
 
 
 class TestHandlePreToolUse:
@@ -255,6 +290,19 @@ class TestHandlePreToolUse:
         assert hook_output["permissionDecision"] == "deny"
         assert "/src/feature.py" in hook_output["permissionDecisionReason"]
 
+    def test_no_output_when_not_initialized(self, tmp_path, capsys):
+        """No output when config.json is absent, even for git commit (#17)."""
+        dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        dirty.parent.mkdir(parents=True)
+        dirty.write_text("/src/feature.py\n")
+
+        input_data = {
+            "hook_event_name": "PreToolUse",
+            "tool_input": {"command": "git commit -m 'test'"},
+        }
+        trigger.handle_pre_tool_use(input_data, str(tmp_path))
+        assert capsys.readouterr().out == ""
+
 
 class TestEventRouting:
     """Tests for main() event routing - the core consolidation logic.
@@ -265,8 +313,10 @@ class TestEventRouting:
 
     def test_routes_stop_event(self, tmp_path):
         """Routes to handle_stop when hook_event_name is Stop."""
-        dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty.parent.mkdir(parents=True)
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+        dirty = config_dir / "dirty-files"
         dirty.write_text("/file.py\n")
 
         stdin_data = json.dumps({"hook_event_name": "Stop"})
@@ -310,8 +360,10 @@ class TestEventRouting:
 
     def test_defaults_to_stop_when_no_event_name(self, tmp_path):
         """Defaults to Stop handler when hook_event_name is missing."""
-        dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
-        dirty.parent.mkdir(parents=True)
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+        dirty = config_dir / "dirty-files"
         dirty.write_text("/file.py\n")
 
         with (

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -290,10 +290,12 @@ class TestEventRouting:
         (config_dir / "config.json").write_text(json.dumps({"triggerMode": "gitmode"}))
         (config_dir / "dirty-files").write_text("/file.py\n")
 
-        stdin_data = json.dumps({
-            "hook_event_name": "PreToolUse",
-            "tool_input": {"command": "git commit -m 'test'"},
-        })
+        stdin_data = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {"command": "git commit -m 'test'"},
+            }
+        )
         with (
             patch.dict("os.environ", {"CLAUDE_PROJECT_DIR": str(tmp_path)}),
             patch("sys.stdin") as mock_stdin,
@@ -390,16 +392,20 @@ class TestHandleSubagentStop:
         trigger.handle_subagent_stop(str(tmp_path))
         assert dirty.read_text() == ""
 
-    def test_noop_when_no_config(self, tmp_path):
-        """Does nothing when config.json is missing (plugin not active)."""
+    def test_clears_even_when_config_missing(self, tmp_path):
+        """Still clears dirty-files when config.json is missing (#17, #25).
+
+        Regression gate: the previous early-return guard caused an
+        infinite Stop-hook loop on uninitialized projects, because
+        dirty-files was never cleaned up and the Stop hook kept firing.
+        """
         dirty_dir = tmp_path / ".claude" / "auto-memory"
         dirty_dir.mkdir(parents=True)
         dirty = dirty_dir / "dirty-files"
         dirty.write_text("/file.py\n")
 
         trigger.handle_subagent_stop(str(tmp_path))
-        # dirty-files should remain unchanged
-        assert dirty.read_text() == "/file.py\n"
+        assert dirty.read_text() == ""
 
     def test_noop_when_dirty_files_empty(self, tmp_path):
         """Does nothing when dirty-files is empty (nothing to clean up)."""

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -4,16 +4,15 @@ Tests internal functions directly (no subprocess), complementing the
 subprocess-based integration tests in test_hooks.py.
 """
 
+import importlib
 import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
-# Import trigger.py module
+# Make scripts/ importable so we can load trigger.py as a module.
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
-import importlib
-
 trigger = importlib.import_module("trigger")
 sys.path.pop(0)
 
@@ -290,10 +289,12 @@ class TestEventRouting:
         (config_dir / "config.json").write_text(json.dumps({"triggerMode": "gitmode"}))
         (config_dir / "dirty-files").write_text("/file.py\n")
 
-        stdin_data = json.dumps({
-            "hook_event_name": "PreToolUse",
-            "tool_input": {"command": "git commit -m 'test'"},
-        })
+        stdin_data = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {"command": "git commit -m 'test'"},
+            }
+        )
         with (
             patch.dict("os.environ", {"CLAUDE_PROJECT_DIR": str(tmp_path)}),
             patch("sys.stdin") as mock_stdin,

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "claude-code-auto-memory"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Bundles four fixes that share adjacent code surface in `scripts/trigger.py` and `scripts/post-tool-use.py`.

### Fixes #17 - Skip hooks on uninitialized projects *(primary loop prevention)*
Added `plugin_initialized()` guard in `post-tool-use.py`, `handle_stop()`, and `handle_pre_tool_use()`. Projects without `config.json` (never ran `/auto-memory:init`) are now fully inert — no dirty-files written, no agent spawned, no git commit interception.

**This is the primary fix for the infinite loop on uninitialized projects.** Because dirty-files is never written, the Stop hook never blocks, and the SubagentStop reliability question is irrelevant for this case.

### Fixes #25 - SubagentStop cleanup *(defensive, best-effort)*
Removed the `config.json` early-return guard in `handle_subagent_stop()` and updated the SubagentStop matcher from `"memory-updater"` to `"(auto-memory:)?memory-updater$"`.

**Important caveat**: @itsxScrubz reported on #25 that SubagentStop does not fire at all for agents spawned via the `Agent` tool on Claude Code 2.1.70 (macOS 26.3.1), regardless of matcher value. This was not reproducible in our test environment (empirical Phase A validation in original PR description). The SubagentStop fix is therefore best-effort — it correctly handles the case where the event does fire, but cannot fix the case where Claude Code doesn't emit it. If SubagentStop doesn't fire on your version, dirty-files will accumulate on initialized projects and the Stop hook will re-block each turn until manually cleared — this is pre-existing behavior this PR does not make worse.

### Fixes #26 - Windows path quoting
Quoted `${CLAUDE_PLUGIN_ROOT}` in all four hook commands. Unquoted expansion broke on Windows profile paths containing spaces.

### Absorbs #28 - Type annotation cleanup
Merged `chore/fix-lint-and-type-errors` directly into this branch. Includes `dict[str, Any]` generics, typed `main() -> None`, narrowed `handle_git_commit` return type. PR #28 closed.

## Tests
- `uv run pytest tests/` → 132 passed
- `uv run ruff check .` → clean
- `uv run mypy scripts/` → clean
- New: `TestPluginInitialized` (3 unit tests), 4 subprocess regression tests for the #17 guard, updated pre-existing tests to create `config.json` where needed

## Test plan
- [x] `uv run pytest tests/` 132/132 passing
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy scripts/` clean
- [ ] Windows verification by @ashifhusainoo7 (#26)