### PR TITLE
Fix pre-existing ruff and mypy strict-mode violations

### DIFF
--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -21,21 +21,23 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
-def load_config(project_dir: str) -> dict:
+def load_config(project_dir: str) -> dict[str, Any]:
     """Load plugin configuration from .claude/auto-memory/config.json."""
     config_file = Path(project_dir) / ".claude" / "auto-memory" / "config.json"
     if config_file.exists():
         try:
             with open(config_file) as f:
-                return json.load(f)
+                data: dict[str, Any] = json.load(f)
+                return data
         except (json.JSONDecodeError, OSError):
             pass
     return {"triggerMode": "default"}
 
 
-def handle_git_commit(project_dir: str) -> tuple[list[str], dict | None]:
+def handle_git_commit(project_dir: str) -> tuple[list[str], dict[str, str] | None]:
     """Extract context from a git commit.
 
     Returns: (files, commit_context) where commit_context is {"hash": ..., "message": ...}
@@ -229,7 +231,7 @@ def extract_files_from_bash(command: str, project_dir: str) -> list[str]:
     return resolved
 
 
-def main():
+def main() -> None:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
 
     # CLAUDE_PROJECT_DIR is required - don't use cwd fallback as it may be wrong
@@ -238,6 +240,7 @@ def main():
         return
 
     # Read tool input from stdin (JSON format)
+    tool_input: dict[str, Any]
     try:
         stdin_data = sys.stdin.read()
         tool_input = json.loads(stdin_data) if stdin_data else {}

--- a/scripts/trigger.py
+++ b/scripts/trigger.py
@@ -17,15 +17,17 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 
-def load_config(project_dir: str) -> dict:
+def load_config(project_dir: str) -> dict[str, Any]:
     """Load plugin configuration from .claude/auto-memory/config.json."""
     config_file = Path(project_dir) / ".claude" / "auto-memory" / "config.json"
     if config_file.exists():
         try:
             with open(config_file) as f:
-                return json.load(f)
+                data: dict[str, Any] = json.load(f)
+                return data
         except (json.JSONDecodeError, OSError):
             pass
     return {"triggerMode": "default"}
@@ -67,7 +69,7 @@ def build_spawn_reason(files: list[str]) -> str:
     )
 
 
-def handle_stop(input_data: dict, project_dir: str) -> None:
+def handle_stop(input_data: dict[str, Any], project_dir: str) -> None:
     """Handle Stop hook event."""
     # Prevent infinite loop when stop_hook_active is set
     if input_data.get("stop_hook_active", False):
@@ -120,7 +122,7 @@ def handle_subagent_stop(project_dir: str) -> None:
     clear_dirty_files(project_dir)
 
 
-def handle_pre_tool_use(input_data: dict, project_dir: str) -> None:
+def handle_pre_tool_use(input_data: dict[str, Any], project_dir: str) -> None:
     """Handle PreToolUse hook event.
 
     Only active in gitmode. Denies git commit commands when dirty files
@@ -160,12 +162,13 @@ def handle_pre_tool_use(input_data: dict, project_dir: str) -> None:
     print(json.dumps(output))
 
 
-def main():
+def main() -> None:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
     if not project_dir:
         return
 
     # Read stdin JSON to determine which hook event fired
+    input_data: dict[str, Any]
     try:
         input_data = json.loads(sys.stdin.read())
     except json.JSONDecodeError:

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -4,16 +4,15 @@ Tests internal functions directly (no subprocess), complementing the
 subprocess-based integration tests in test_hooks.py.
 """
 
+import importlib
 import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
-# Import trigger.py module
+# Make scripts/ importable so we can load trigger.py as a module.
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
-import importlib
-
 trigger = importlib.import_module("trigger")
 sys.path.pop(0)
 
@@ -290,10 +289,12 @@ class TestEventRouting:
         (config_dir / "config.json").write_text(json.dumps({"triggerMode": "gitmode"}))
         (config_dir / "dirty-files").write_text("/file.py\n")
 
-        stdin_data = json.dumps({
-            "hook_event_name": "PreToolUse",
-            "tool_input": {"command": "git commit -m 'test'"},
-        })
+        stdin_data = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_input": {"command": "git commit -m 'test'"},
+            }
+        )
         with (
             patch.dict("os.environ", {"CLAUDE_PROJECT_DIR": str(tmp_path)}),
             patch("sys.stdin") as mock_stdin,


### PR DESCRIPTION
## Summary

Cleans up 12 pre-existing lint/type errors on `main` that were blocking `uv run ruff check .` and `uv run mypy scripts/` from returning clean:

- **ruff** (1): `E402` in `tests/test_trigger.py` - `import importlib` sat below a `sys.path.insert` call. `importlib` is stdlib and has no path dependency, so it moves cleanly to the top-of-file imports block.
- **mypy strict** (11): Missing generic parameters on `dict`, `no-any-return` on `json.load`, untyped `main()` functions, and an overly loose return type on `handle_git_commit`.

These existed on `main` before any recent PRs - verified via `git stash` + baseline run. No runtime behaviour changes in this PR.

## Why bother

Baseline noise in lint/type output makes it hard to tell real issues from accepted ones in future PRs. With the baseline clean, any new violation stands out immediately instead of being hidden in a pile of 12 pre-existing errors. This is groundwork for eventually adding these checks to a pre-commit hook or GitHub Action.

## Changes

| File | Change |
|---|---|
| `scripts/trigger.py` | Import `typing.Any`; `dict` -> `dict[str, Any]` on `load_config`, `handle_stop`, `handle_pre_tool_use`; annotate `main() -> None`; typed local for stdin parse |
| `scripts/post-tool-use.py` | Same `typing.Any` + `dict[str, Any]` treatment on `load_config` and `main()`; narrow `handle_git_commit` return to `dict[str, str] \| None` matching the real `{"hash", "message"}` shape |
| `tests/test_trigger.py` | Move `import importlib` to top-level imports |

## Verification

```bash
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
7 files already formatted

$ uv run mypy scripts/
Success: no issues found in 2 source files

$ uv run pytest tests/
============================= 123 passed in 0.90s ==============================
```

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy scripts/` clean
- [x] `uv run pytest tests/` 123/123 passing
- [x] No runtime behaviour changes (only type annotations and import order)

## Relationship to #27

Independent cleanup PR. #27 fixes bugs; this one fixes the baseline. Merging either first works; if #27 merges first, a trivial rebase may be needed here.