### PR TITLE
Fix SubagentStop cleanup: add subagent_type to spawn instructions and ^ anchor to matcher

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-memory",
   "description": "Automatically maintains CLAUDE.md files as codebases evolve using hooks, agents, and skills",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": {
     "name": "severity1"
   },

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -36,7 +36,7 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "(auto-memory:)?memory-updater$",
+        "matcher": "^(auto-memory:)?memory-updater$",
         "hooks": [
           {
             "type": "command",

--- a/scripts/trigger.py
+++ b/scripts/trigger.py
@@ -76,7 +76,8 @@ def build_spawn_reason(files: list[str]) -> str:
     return (
         f"Files were modified this turn. Use the Task tool with "
         f"run_in_background set to false and mode set to bypassPermissions "
-        f"to spawn 'memory-updater' agent with prompt: 'Update CLAUDE.md for "
+        f"to spawn 'memory-updater' agent with subagent_type set to "
+        f"'auto-memory:memory-updater' and prompt: 'Update CLAUDE.md for "
         f"changed files: {files_str}'. After the agent completes, use the "
         f"Read tool to read the root CLAUDE.md file to refresh your memory."
     )
@@ -172,9 +173,10 @@ def handle_pre_tool_use(input_data: dict[str, Any], project_dir: str) -> None:
             "permissionDecisionReason": (
                 f"Files were modified since last memory update. Use the Task tool "
                 f"with run_in_background set to false and mode set to "
-                f"bypassPermissions to spawn 'memory-updater' agent with prompt: "
-                f"'Update CLAUDE.md for changed files: {files_str}'. After the "
-                f"agent completes, retry the git commit."
+                f"bypassPermissions to spawn 'memory-updater' agent with subagent_type "
+                f"set to 'auto-memory:memory-updater' and prompt: 'Update CLAUDE.md "
+                f"for changed files: {files_str}'. After the agent completes, retry "
+                f"the git commit."
             ),
         }
     }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,7 +102,7 @@ class TestHooksConfiguration:
         Claude Code resolves plugin-scoped subagent names at runtime (#25).
         """
         subagent_stop = hooks_json["hooks"]["SubagentStop"][0]
-        assert subagent_stop["matcher"] == "(auto-memory:)?memory-updater$"
+        assert subagent_stop["matcher"] == "^(auto-memory:)?memory-updater$"
 
     def test_hook_commands_quote_plugin_root(self, hooks_json):
         """All hook commands quote ${CLAUDE_PLUGIN_ROOT} for Windows paths with spaces (#26).


### PR DESCRIPTION
## Summary

- SubagentStop hook was not firing after memory-updater agent completed because Claude Code matches the hook against `subagent_type`, not the `name` parameter
- Stop and PreToolUse hook messages now instruct Claude to set `subagent_type='auto-memory:memory-updater'` when spawning the agent
- Added `^` start anchor to SubagentStop regex matcher to prevent partial matches
- Bumps to v0.8.4

## Root cause

The SubagentStop matcher `(auto-memory:)?memory-updater$` was correct, but the agent was being spawned without `subagent_type` set. Claude Code resolves SubagentStop hooks against `subagent_type`, not the agent `name`. Dirty-files was never cleared, causing the Stop hook to block every subsequent turn.

## Test plan

- [ ] Create a file, verify PostToolUse tracks it in dirty-files
- [ ] End turn, verify Stop hook fires and requests agent spawn with `subagent_type='auto-memory:memory-updater'`
- [ ] Verify SubagentStop fires after agent completes and clears dirty-files
- [ ] All 132 tests pass