### PR TITLE
Add session-aware dirty-files and auto-commit/push toggle (#16, #18)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-memory",
   "description": "Automatically maintains CLAUDE.md files as codebases evolve using hooks, agents, and skills",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "author": {
     "name": "severity1"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Configuration:
 - `autoCommit`: When true, auto-commits CLAUDE.md changes after memory-updater completes
 - `autoPush`: When true (requires autoCommit), pushes commits to remote
 - Config stored in `.claude/auto-memory/config.json`
+- Init wizard interactively configures triggerMode, autoCommit, and autoPush, then updates `.gitignore` to exclude `dirty-files*` tracking files
 
 <!-- END AUTO-MANAGED -->
 
@@ -114,6 +115,8 @@ Configuration:
 - **Inline Commit Context**: Commit hash and message stored inline with file paths in dirty-files (`/path/to/file [hash: message]`)
 - **Session Isolation Pattern**: `session_id` from hook stdin JSON used to scope dirty-files per session, with fallback to shared file for backwards compatibility
 - **Stale Session Cleanup Pattern**: `cleanup_stale_session_files()` removes orphaned session dirty-files older than 24h on each SubagentStop
+- **Dirty-Files Read Order**: memory-updater reads plain `dirty-files` first; checks session-specific `dirty-files-*` files only if plain file is empty or missing
+- **Gitignore Management Pattern**: `/auto-memory:init` appends `.claude/auto-memory/dirty-files*` to `.gitignore` (creates file if absent) so tracking files are never committed
 
 <!-- END AUTO-MANAGED -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,14 +71,16 @@ tests/
 
 Data flow:
 1. User edits files via Edit/Write tools or git operations (rm, mv)
-2. PostToolUse hook appends paths to `.claude/auto-memory/dirty-files`
+2. PostToolUse hook appends paths to session-specific `.claude/auto-memory/dirty-files-{session_id}` (falls back to `dirty-files` without session_id)
 3. PreToolUse hook (gitmode only) denies git commit until dirty files processed
 4. Stop hook detects dirty files, blocks Claude, requests agent spawn
 5. memory-updater agent processes files and updates CLAUDE.md
-6. SubagentStop hook clears dirty-files after agent completes
+6. SubagentStop hook auto-commits CLAUDE.md (if configured), clears dirty-files, cleans up stale session files
 
 Configuration:
 - Trigger modes: `default` (after every turn) or `gitmode` (only after git commits)
+- `autoCommit`: When true, auto-commits CLAUDE.md changes after memory-updater completes
+- `autoPush`: When true (requires autoCommit), pushes commits to remote
 - Config stored in `.claude/auto-memory/config.json`
 
 <!-- END AUTO-MANAGED -->
@@ -105,11 +107,13 @@ Configuration:
 - **Initialization Guard Pattern**: `plugin_initialized()` in post-tool-use.py, handle_stop(), and handle_pre_tool_use() gates all activity on config.json existence — projects that never ran /auto-memory:init are fully inert
 - **Hook Lifecycle Pattern**: PostToolUse tracks → Stop/PreToolUse blocks → Agent spawns → SubagentStop cleans up (cleanup gated on dirty-files only, not config.json, to prevent infinite loops)
 - **Separation of Concerns**: PostToolUse (silent tracking) vs Stop/PreToolUse (blocking with output) vs SubagentStop (cleanup)
-- **Dirty File Pattern**: Append-only tracking, batch processing at turn end
+- **Dirty File Pattern**: Append-only tracking, batch processing at turn end, session-isolated via `dirty-files-{session_id}`
 - **Skill Pattern**: YAML frontmatter + markdown body with algorithm sections
 - **Template Pattern**: AUTO-MANAGED markers for updatable sections
-- **Config Pattern**: JSON config in `.claude/auto-memory/config.json`
+- **Config Pattern**: JSON config in `.claude/auto-memory/config.json` with `triggerMode`, `autoCommit`, `autoPush`
 - **Inline Commit Context**: Commit hash and message stored inline with file paths in dirty-files (`/path/to/file [hash: message]`)
+- **Session Isolation Pattern**: `session_id` from hook stdin JSON used to scope dirty-files per session, with fallback to shared file for backwards compatibility
+- **Stale Session Cleanup Pattern**: `cleanup_stale_session_files()` removes orphaned session dirty-files older than 24h on each SubagentStop
 
 <!-- END AUTO-MANAGED -->
 
@@ -129,6 +133,10 @@ Recent design decisions from commit history:
 - SubagentStop cleanup gated on dirty-files only (not config.json): requiring config.json caused infinite Stop-hook loops on uninitialized projects where dirty-files never got cleared
 - Initialization guard added (#17): plugin_initialized() check in PostToolUse, Stop, and PreToolUse keeps the plugin fully inert on projects that never ran /auto-memory:init
 - Type annotations tightened: dict[str, Any] generics, typed main() -> None, narrowed handle_git_commit return type
+- Session-aware dirty-files (#16): session_id from hook stdin JSON scopes dirty-files per session, preventing cross-session interference in concurrent workflows
+- Auto-commit/push toggle (#18): autoCommit and autoPush config options in SubagentStop handler, commits only CLAUDE.md files with graceful failure handling
+- handle_subagent_stop signature changed from (project_dir) to (input_data, project_dir) to receive session_id and support auto-commit config loading
+- SubagentStop cleanup fix (#28/#29): build_spawn_reason() now explicitly passes subagent_type='auto-memory:memory-updater' in Task tool spawn instructions - omitting it caused SubagentStop to not fire and dirty-files to never be cleared
 
 <!-- END AUTO-MANAGED -->
 

--- a/agents/memory-updater.md
+++ b/agents/memory-updater.md
@@ -10,7 +10,7 @@ You are the memory-updater agent. Your job is to gather context about file chang
 ## Workflow
 
 ### Phase 1: Load Dirty Files
-1. Read `.claude/auto-memory/dirty-files` using Read tool
+1. Read `.claude/auto-memory/dirty-files` using Read tool (also check for session-specific `dirty-files-*` files if the plain file is empty or missing)
 2. Parse each line - two formats:
    - Plain path: `/path/to/file`
    - With commit context: `/path/to/file [hash: commit message]`

--- a/commands/init.md
+++ b/commands/init.md
@@ -23,17 +23,48 @@ Save the selection to `.claude/auto-memory/config.json`:
 }
 ```
 
-Also ensure `.gitignore` includes the dirty-files tracking file:
+### Step 1b: Configure Auto-Commit (Optional)
+
+Ask the user if they want CLAUDE.md changes auto-committed using AskUserQuestion:
+
+**Question**: "Should auto-memory automatically commit CLAUDE.md changes after updates?"
+
+**Options**:
+- **No** (default): CLAUDE.md changes remain as local modifications. You commit them manually.
+- **Yes**: Automatically commit CLAUDE.md files after each memory update. Commit message: `chore: update CLAUDE.md [auto-memory]`
+
+If the user selects Yes, also ask about auto-push:
+
+**Question**: "Should auto-memory also push CLAUDE.md commits to the remote?"
+
+**Options**:
+- **No** (default): Commits stay local until you push manually.
+- **Yes**: Automatically push after each auto-commit.
+
+Update `.claude/auto-memory/config.json` with the selections:
+```json
+{
+  "triggerMode": "default",
+  "autoCommit": false,
+  "autoPush": false
+}
+```
+
+### Step 1c: Update .gitignore
+
+Also ensure `.gitignore` includes the dirty-files tracking files:
 1. Check if `.gitignore` exists in the project root
-2. If it exists, check if it already contains `.claude/auto-memory/dirty-files`
-3. If not present, append the entry under a `# Claude Code auto-memory` comment section
-4. If `.gitignore` doesn't exist, create it with the entry
+2. If it exists, check if it already contains `.claude/auto-memory/dirty-files*`
+3. If not present, append the entries under a `# Claude Code auto-memory` comment section
+4. If `.gitignore` doesn't exist, create it with the entries
 
 Example addition to `.gitignore`:
 ```
 # Claude Code auto-memory
-.claude/auto-memory/dirty-files
+.claude/auto-memory/dirty-files*
 ```
+
+Note: The wildcard pattern covers both the legacy `dirty-files` and session-specific `dirty-files-{session_id}` files.
 
 ### Step 2: Analyze Codebase
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -5,8 +5,9 @@ description: Show CLAUDE.md memory sync status
 Display the current status of CLAUDE.md memory synchronization.
 
 Check and report:
-1. **Pending changes**: Count of files in `.claude/auto-memory/dirty-files` awaiting processing
+1. **Pending changes**: Count of files in `.claude/auto-memory/dirty-files` (or session-specific `dirty-files-*` files) awaiting processing
 2. **Last sync**: Modification timestamp of CLAUDE.md
 3. **CLAUDE.md locations**: All CLAUDE.md files found in the project
+4. **Configuration**: Current trigger mode, autoCommit, and autoPush settings from `.claude/auto-memory/config.json`
 
 If there are pending changes, offer to run `/auto-memory:calibrate` to process them.

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -27,7 +27,7 @@ Use this when you've edited files manually (outside Claude Code) and want to upd
 
 5. **If changes found**:
    - Convert paths to absolute paths
-   - Write to `.claude/auto-memory/dirty-files` (one path per line)
+   - Write to `.claude/auto-memory/dirty-files` (one path per line, or `dirty-files-{session_id}` if session_id is available from the environment)
    - Use the Task tool to spawn the `memory-updater` agent with prompt:
      "Update CLAUDE.md for manually changed files: [file list]"
 

--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -87,6 +87,14 @@ def handle_git_commit(project_dir: str) -> tuple[list[str], dict[str, str] | Non
     return files, {"hash": commit_hash, "message": commit_message}
 
 
+def dirty_file_path(project_dir: str, session_id: str = "") -> Path:
+    """Return path to session-specific or default dirty-files."""
+    base = Path(project_dir) / ".claude" / "auto-memory"
+    if session_id:
+        return base / f"dirty-files-{session_id}"
+    return base / "dirty-files"
+
+
 def should_track(file_path: str, project_dir: str) -> bool:
     """Check if file should be tracked for CLAUDE.md updates."""
     path = Path(file_path)
@@ -266,6 +274,7 @@ def main() -> None:
 
     tool_name = tool_input.get("tool_name", "")
     tool_input_data = tool_input.get("tool_input", {})
+    session_id = tool_input.get("session_id", "")
 
     # Load configuration
     config = load_config(project_dir)
@@ -320,7 +329,7 @@ def main() -> None:
         return
 
     # Read existing dirty files into a dict (path -> full line)
-    dirty_file = Path(project_dir) / ".claude" / "auto-memory" / "dirty-files"
+    dirty_file = dirty_file_path(project_dir, session_id)
     dirty_file.parent.mkdir(parents=True, exist_ok=True)
     existing: dict[str, str] = {}
     if dirty_file.exists():

--- a/scripts/trigger.py
+++ b/scripts/trigger.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -46,12 +48,20 @@ def load_config(project_dir: str) -> dict[str, Any]:
     return {"triggerMode": "default"}
 
 
-def read_dirty_files(project_dir: str) -> list[str]:
+def dirty_file_path(project_dir: str, session_id: str = "") -> Path:
+    """Return path to session-specific or default dirty-files."""
+    base = Path(project_dir) / ".claude" / "auto-memory"
+    if session_id:
+        return base / f"dirty-files-{session_id}"
+    return base / "dirty-files"
+
+
+def read_dirty_files(project_dir: str, session_id: str = "") -> list[str]:
     """Read and deduplicate dirty files, stripping commit context.
 
     Returns sorted list of file paths (max 20).
     """
-    dirty_file = Path(project_dir) / ".claude" / "auto-memory" / "dirty-files"
+    dirty_file = dirty_file_path(project_dir, session_id)
 
     if not dirty_file.exists() or dirty_file.stat().st_size == 0:
         return []
@@ -100,7 +110,8 @@ def handle_stop(input_data: dict[str, Any], project_dir: str) -> None:
     # (PreToolUse only intercepts before the next git commit, not after the last one)
     # So we don't skip Stop in gitmode - it acts as the final safety net.
 
-    files = read_dirty_files(project_dir)
+    session_id = input_data.get("session_id", "")
+    files = read_dirty_files(project_dir, session_id)
     if not files:
         return
 
@@ -115,14 +126,84 @@ def handle_stop(input_data: dict[str, Any], project_dir: str) -> None:
     print(json.dumps(output))
 
 
-def clear_dirty_files(project_dir: str) -> None:
+def clear_dirty_files(project_dir: str, session_id: str = "") -> None:
     """Truncate dirty-files to clear processed entries."""
-    dirty_file = Path(project_dir) / ".claude" / "auto-memory" / "dirty-files"
+    dirty_file = dirty_file_path(project_dir, session_id)
     if dirty_file.exists():
         dirty_file.write_text("")
 
 
-def handle_subagent_stop(project_dir: str) -> None:
+def cleanup_stale_session_files(project_dir: str, max_age_hours: int = 24) -> None:
+    """Remove session-specific dirty-files older than max_age_hours.
+
+    Only removes files matching dirty-files-* pattern. Never removes
+    the plain dirty-files (backwards compatibility).
+    """
+    auto_memory_dir = Path(project_dir) / ".claude" / "auto-memory"
+    if not auto_memory_dir.exists():
+        return
+
+    cutoff = time.time() - (max_age_hours * 3600)
+    for f in auto_memory_dir.glob("dirty-files-*"):
+        try:
+            if f.stat().st_mtime < cutoff:
+                f.unlink()
+        except OSError:
+            pass
+
+
+def auto_commit_claude_md(project_dir: str) -> bool:
+    """Stage and commit modified CLAUDE.md files. Returns True on success."""
+    # Find modified CLAUDE.md files (tracked, unstaged changes)
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=M"],
+        capture_output=True,
+        text=True,
+        cwd=project_dir,
+    )
+    if result.returncode != 0:
+        return False
+
+    claude_files = [
+        f.strip()
+        for f in result.stdout.strip().split("\n")
+        if f.strip() and f.strip().endswith("CLAUDE.md")
+    ]
+    if not claude_files:
+        return False
+
+    # Stage only CLAUDE.md files
+    stage = subprocess.run(
+        ["git", "add"] + claude_files,
+        capture_output=True,
+        text=True,
+        cwd=project_dir,
+    )
+    if stage.returncode != 0:
+        return False
+
+    # Commit
+    commit = subprocess.run(
+        ["git", "commit", "-m", "chore: update CLAUDE.md [auto-memory]"],
+        capture_output=True,
+        text=True,
+        cwd=project_dir,
+    )
+    return commit.returncode == 0
+
+
+def auto_push(project_dir: str) -> bool:
+    """Push current branch to remote. Returns True on success."""
+    result = subprocess.run(
+        ["git", "push"],
+        capture_output=True,
+        text=True,
+        cwd=project_dir,
+    )
+    return result.returncode == 0
+
+
+def handle_subagent_stop(input_data: dict[str, Any], project_dir: str) -> None:
     """Handle SubagentStop hook event.
 
     Clears dirty-files after the memory-updater agent completes. Gated on
@@ -130,12 +211,24 @@ def handle_subagent_stop(project_dir: str) -> None:
     config.json to exist, because doing so caused an infinite Stop-hook
     loop on uninitialized projects (#17, #25): the Stop hook would
     re-fire every turn on stale dirty-files that never got cleared.
+
+    When autoCommit is enabled, commits modified CLAUDE.md files before
+    clearing dirty-files (#18).
     """
-    files = read_dirty_files(project_dir)
+    session_id = input_data.get("session_id", "")
+    files = read_dirty_files(project_dir, session_id)
     if not files:
         return
 
-    clear_dirty_files(project_dir)
+    # Auto-commit/push before clearing dirty files
+    config = load_config(project_dir)
+    if config.get("autoCommit", False):
+        if auto_commit_claude_md(project_dir):
+            if config.get("autoPush", False):
+                auto_push(project_dir)
+
+    clear_dirty_files(project_dir, session_id)
+    cleanup_stale_session_files(project_dir)
 
 
 def handle_pre_tool_use(input_data: dict[str, Any], project_dir: str) -> None:
@@ -161,7 +254,8 @@ def handle_pre_tool_use(input_data: dict[str, Any], project_dir: str) -> None:
     if "git commit" not in command:
         return
 
-    files = read_dirty_files(project_dir)
+    session_id = input_data.get("session_id", "")
+    files = read_dirty_files(project_dir, session_id)
     if not files:
         return
 
@@ -200,7 +294,7 @@ def main() -> None:
     if hook_event == "PreToolUse":
         handle_pre_tool_use(input_data, project_dir)
     elif hook_event == "SubagentStop":
-        handle_subagent_stop(project_dir)
+        handle_subagent_stop(input_data, project_dir)
     else:
         # Default to Stop behavior (for backwards compatibility and
         # when hook_event_name is missing or "Stop")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -390,6 +390,50 @@ class TestPostToolUseHook:
         dirty_file = tmp_path / ".claude" / "auto-memory" / "dirty-files"
         assert not dirty_file.exists()
 
+    def test_writes_session_specific_dirty_file(self, tmp_path):
+        """With session_id in stdin JSON, writes to dirty-files-{session_id}."""
+        self._init_config(tmp_path)
+        file_path = str(tmp_path / "feature.py")
+        stdin_data = json.dumps(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": file_path},
+                "session_id": "sess-abc-123",
+            }
+        )
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
+            env={**os.environ, **env},
+            input=stdin_data,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        session_dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files-sess-abc-123"
+        assert session_dirty.exists()
+        assert file_path in session_dirty.read_text()
+        # Plain dirty-files should NOT exist
+        plain_dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        assert not plain_dirty.exists()
+
+    def test_falls_back_to_plain_dirty_file(self, tmp_path):
+        """Without session_id, writes to plain dirty-files."""
+        self._init_config(tmp_path)
+        file_path = str(tmp_path / "legacy.py")
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
+            env={**os.environ, **env},
+            input=self._make_tool_input(file_path),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        plain_dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
+        assert plain_dirty.exists()
+        assert file_path in plain_dirty.read_text()
+
 
 class TestStopHook:
     """Tests for trigger.py Stop hook behavior."""
@@ -767,6 +811,96 @@ class TestSubagentStopHook:
         assert result.returncode == 0
         assert result.stdout == ""
         assert dirty_file.read_text() == ""
+
+    def test_clears_session_specific_dirty_file(self, tmp_path):
+        """With session_id, clears only that session's dirty-file."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+        (config_dir / "dirty-files-sess-int").write_text("/a.py\n")
+        (config_dir / "dirty-files-sess-other").write_text("/b.py\n")
+
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "trigger.py"],
+            env={**os.environ, **env},
+            input=json.dumps(
+                {
+                    "hook_event_name": "SubagentStop",
+                    "session_id": "sess-int",
+                }
+            ),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+        assert (config_dir / "dirty-files-sess-int").read_text() == ""
+        assert (config_dir / "dirty-files-sess-other").read_text() == "/b.py\n"
+
+    def test_auto_commit_on_subagent_stop(self, tmp_path):
+        """With autoCommit config, commits CLAUDE.md after agent completes."""
+        # Set up git repo
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        (tmp_path / ".gitkeep").write_text("")
+        subprocess.run(["git", "add", ".gitkeep"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        # Set up config with autoCommit
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(
+            json.dumps({"triggerMode": "default", "autoCommit": True})
+        )
+
+        # Create and commit CLAUDE.md, then modify it
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Initial")
+        subprocess.run(["git", "add", "CLAUDE.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add CLAUDE.md"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        claude_md.write_text("# Updated by memory-updater")
+
+        # Write dirty-files so SubagentStop has something to process
+        (config_dir / "dirty-files").write_text("/some/file.py\n")
+
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "trigger.py"],
+            env={**os.environ, **env},
+            input=json.dumps({"hook_event_name": "SubagentStop"}),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+        # Verify CLAUDE.md was committed
+        log = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "CLAUDE.md" in log.stdout
+        assert "[auto-memory]" in log.stdout
 
 
 class TestGitCommitContext:

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -6,7 +6,10 @@ subprocess-based integration tests in test_hooks.py.
 
 import importlib
 import json
+import os
+import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,6 +18,28 @@ SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 trigger = importlib.import_module("trigger")
 sys.path.pop(0)
+
+
+class TestDirtyFilePath:
+    """Tests for dirty_file_path - returns session-specific or default dirty-files path."""
+
+    def test_returns_session_specific_path(self, tmp_path):
+        """With session_id, returns dirty-files-{session_id}."""
+        result = trigger.dirty_file_path(str(tmp_path), "abc-123")
+        expected = Path(tmp_path) / ".claude" / "auto-memory" / "dirty-files-abc-123"
+        assert result == expected
+
+    def test_returns_default_path_without_session(self, tmp_path):
+        """Without session_id, returns plain dirty-files."""
+        result = trigger.dirty_file_path(str(tmp_path))
+        expected = Path(tmp_path) / ".claude" / "auto-memory" / "dirty-files"
+        assert result == expected
+
+    def test_returns_default_path_with_empty_session(self, tmp_path):
+        """Empty string session_id returns plain dirty-files."""
+        result = trigger.dirty_file_path(str(tmp_path), "")
+        expected = Path(tmp_path) / ".claude" / "auto-memory" / "dirty-files"
+        assert result == expected
 
 
 class TestLoadConfig:
@@ -53,6 +78,28 @@ class TestLoadConfig:
 
         config = trigger.load_config(str(tmp_path))
         assert config["customField"] == "value"
+
+    def test_default_auto_commit_false(self, tmp_path):
+        """Default config does not include autoCommit (treated as false)."""
+        config = trigger.load_config(str(tmp_path))
+        assert config.get("autoCommit", False) is False
+
+    def test_default_auto_push_false(self, tmp_path):
+        """Default config does not include autoPush (treated as false)."""
+        config = trigger.load_config(str(tmp_path))
+        assert config.get("autoPush", False) is False
+
+    def test_reads_auto_commit_config(self, tmp_path):
+        """Reads autoCommit and autoPush from config file."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(
+            json.dumps({"triggerMode": "default", "autoCommit": True, "autoPush": True})
+        )
+
+        config = trigger.load_config(str(tmp_path))
+        assert config["autoCommit"] is True
+        assert config["autoPush"] is True
 
 
 class TestPluginInitialized:
@@ -151,6 +198,28 @@ class TestReadDirtyFiles:
         files = trigger.read_dirty_files(str(tmp_path))
         assert files == ["/a.py", "/b.py"]
 
+    def test_reads_session_specific_file(self, tmp_path):
+        """Reads from dirty-files-{session_id} when session_id provided."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+        (session_dir / "dirty-files-sess-001").write_text("/src/a.py\n")
+        # Also create a plain dirty-files with different content
+        (session_dir / "dirty-files").write_text("/src/b.py\n")
+
+        files = trigger.read_dirty_files(str(tmp_path), session_id="sess-001")
+        assert files == ["/src/a.py"]
+
+    def test_ignores_other_session_files(self, tmp_path):
+        """Only reads own session's file, not other sessions'."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+        (session_dir / "dirty-files-sess-001").write_text("/src/a.py\n")
+        (session_dir / "dirty-files-sess-002").write_text("/src/b.py\n")
+
+        files = trigger.read_dirty_files(str(tmp_path), session_id="sess-001")
+        assert files == ["/src/a.py"]
+        assert "/src/b.py" not in files
+
 
 class TestBuildSpawnReason:
     """Tests for build_spawn_reason - constructs agent spawn instruction."""
@@ -224,6 +293,19 @@ class TestHandleStop:
 
         trigger.handle_stop({}, str(tmp_path))
         assert capsys.readouterr().out == ""
+
+    def test_reads_session_specific_dirty_files(self, tmp_path, capsys):
+        """Passes session_id through to read session-specific dirty-files."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+        # Session-specific file has content, plain file does not
+        (config_dir / "dirty-files-sess-xyz").write_text("/src/main.py\n")
+
+        trigger.handle_stop({"session_id": "sess-xyz"}, str(tmp_path))
+        output = json.loads(capsys.readouterr().out)
+        assert output["decision"] == "block"
+        assert "/src/main.py" in output["reason"]
 
 
 class TestHandlePreToolUse:
@@ -409,6 +491,33 @@ class TestEventRouting:
         dirty = config_dir / "dirty-files"
         assert dirty.read_text() == ""
 
+    def test_routes_subagent_stop_with_session_id(self, tmp_path):
+        """SubagentStop passes input_data (including session_id) to handler."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+        (config_dir / "dirty-files-sess-route").write_text("/file.py\n")
+        # Plain dirty-files should NOT be touched
+        (config_dir / "dirty-files").write_text("/other.py\n")
+
+        stdin_data = json.dumps(
+            {
+                "hook_event_name": "SubagentStop",
+                "session_id": "sess-route",
+            }
+        )
+        with (
+            patch.dict("os.environ", {"CLAUDE_PROJECT_DIR": str(tmp_path)}),
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_stdin.read.return_value = stdin_data
+            trigger.main()
+            mock_print.assert_not_called()
+
+        assert (config_dir / "dirty-files-sess-route").read_text() == ""
+        assert (config_dir / "dirty-files").read_text() == "/other.py\n"
+
 
 class TestClearDirtyFiles:
     """Tests for clear_dirty_files - truncates dirty-files."""
@@ -428,6 +537,30 @@ class TestClearDirtyFiles:
         dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
         assert not dirty.exists()
 
+    def test_clears_session_specific_file(self, tmp_path):
+        """Clears only dirty-files-{session_id} when session_id provided."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+        (session_dir / "dirty-files-sess-001").write_text("/src/a.py\n")
+        (session_dir / "dirty-files-sess-002").write_text("/src/b.py\n")
+
+        trigger.clear_dirty_files(str(tmp_path), session_id="sess-001")
+        assert (session_dir / "dirty-files-sess-001").read_text() == ""
+        assert (session_dir / "dirty-files-sess-002").read_text() == "/src/b.py\n"
+
+    def test_leaves_other_session_files(self, tmp_path):
+        """Other sessions' dirty-files are untouched when clearing with session_id."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+        (session_dir / "dirty-files-sess-A").write_text("/a.py\n")
+        (session_dir / "dirty-files-sess-B").write_text("/b.py\n")
+        (session_dir / "dirty-files").write_text("/c.py\n")
+
+        trigger.clear_dirty_files(str(tmp_path), session_id="sess-A")
+        assert (session_dir / "dirty-files-sess-A").read_text() == ""
+        assert (session_dir / "dirty-files-sess-B").read_text() == "/b.py\n"
+        assert (session_dir / "dirty-files").read_text() == "/c.py\n"
+
 
 class TestHandleSubagentStop:
     """Tests for handle_subagent_stop - SubagentStop hook event handler."""
@@ -440,7 +573,7 @@ class TestHandleSubagentStop:
         dirty = config_dir / "dirty-files"
         dirty.write_text("/src/main.py\n/src/util.py\n")
 
-        trigger.handle_subagent_stop(str(tmp_path))
+        trigger.handle_subagent_stop({}, str(tmp_path))
         assert dirty.read_text() == ""
 
     def test_clears_even_when_config_missing(self, tmp_path):
@@ -455,7 +588,7 @@ class TestHandleSubagentStop:
         dirty = dirty_dir / "dirty-files"
         dirty.write_text("/file.py\n")
 
-        trigger.handle_subagent_stop(str(tmp_path))
+        trigger.handle_subagent_stop({}, str(tmp_path))
         assert dirty.read_text() == ""
 
     def test_noop_when_dirty_files_empty(self, tmp_path):
@@ -466,7 +599,7 @@ class TestHandleSubagentStop:
         dirty = config_dir / "dirty-files"
         dirty.write_text("")
 
-        trigger.handle_subagent_stop(str(tmp_path))
+        trigger.handle_subagent_stop({}, str(tmp_path))
         assert dirty.read_text() == ""
 
     def test_noop_when_dirty_files_missing(self, tmp_path):
@@ -475,7 +608,7 @@ class TestHandleSubagentStop:
         config_dir.mkdir(parents=True)
         (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
 
-        trigger.handle_subagent_stop(str(tmp_path))
+        trigger.handle_subagent_stop({}, str(tmp_path))
         dirty = config_dir / "dirty-files"
         assert not dirty.exists()
 
@@ -486,5 +619,269 @@ class TestHandleSubagentStop:
         (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
         (config_dir / "dirty-files").write_text("/file.py\n")
 
-        trigger.handle_subagent_stop(str(tmp_path))
+        trigger.handle_subagent_stop({}, str(tmp_path))
         assert capsys.readouterr().out == ""
+
+    def test_clears_session_specific_file(self, tmp_path):
+        """Clears only own session's dirty-files when session_id provided."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text(json.dumps({"triggerMode": "default"}))
+        (config_dir / "dirty-files-sess-A").write_text("/a.py\n")
+        (config_dir / "dirty-files-sess-B").write_text("/b.py\n")
+
+        trigger.handle_subagent_stop({"session_id": "sess-A"}, str(tmp_path))
+        assert (config_dir / "dirty-files-sess-A").read_text() == ""
+        assert (config_dir / "dirty-files-sess-B").read_text() == "/b.py\n"
+
+
+class TestCleanupStaleSessions:
+    """Tests for cleanup_stale_session_files - removes orphaned session dirty-files."""
+
+    def test_removes_old_session_files(self, tmp_path):
+        """Removes session-specific dirty-files older than max_age_hours."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+        stale = session_dir / "dirty-files-old-session"
+        stale.write_text("/stale.py\n")
+        # Set mtime to 25 hours ago
+        old_time = time.time() - (25 * 3600)
+        os.utime(stale, (old_time, old_time))
+
+        trigger.cleanup_stale_session_files(str(tmp_path), max_age_hours=24)
+        assert not stale.exists()
+
+    def test_keeps_recent_session_files(self, tmp_path):
+        """Keeps session-specific dirty-files younger than max_age_hours."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+        recent = session_dir / "dirty-files-recent-session"
+        recent.write_text("/recent.py\n")
+        # mtime is now (just created), well within 24h
+
+        trigger.cleanup_stale_session_files(str(tmp_path), max_age_hours=24)
+        assert recent.exists()
+        assert recent.read_text() == "/recent.py\n"
+
+    def test_keeps_plain_dirty_files(self, tmp_path):
+        """Never removes the legacy plain dirty-files (no session suffix)."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+        plain = session_dir / "dirty-files"
+        plain.write_text("/legacy.py\n")
+        # Make it old
+        old_time = time.time() - (48 * 3600)
+        os.utime(plain, (old_time, old_time))
+
+        trigger.cleanup_stale_session_files(str(tmp_path), max_age_hours=24)
+        assert plain.exists()
+        assert plain.read_text() == "/legacy.py\n"
+
+    def test_noop_when_no_session_files(self, tmp_path):
+        """No crash when directory has no session files."""
+        session_dir = tmp_path / ".claude" / "auto-memory"
+        session_dir.mkdir(parents=True)
+
+        trigger.cleanup_stale_session_files(str(tmp_path), max_age_hours=24)
+        # Should not raise
+
+    def test_noop_when_directory_missing(self, tmp_path):
+        """No crash when .claude/auto-memory directory doesn't exist."""
+        trigger.cleanup_stale_session_files(str(tmp_path), max_age_hours=24)
+        # Should not raise
+
+
+class TestAutoCommitClaudeMd:
+    """Tests for auto_commit_claude_md - stages and commits CLAUDE.md files."""
+
+    def _init_git_repo(self, tmp_path):
+        """Initialize a git repo with an initial commit."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        init_file = tmp_path / ".gitkeep"
+        init_file.write_text("")
+        subprocess.run(["git", "add", ".gitkeep"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+    def test_commits_modified_claude_md(self, tmp_path):
+        """Stages and commits modified CLAUDE.md files."""
+        self._init_git_repo(tmp_path)
+        # Create and commit CLAUDE.md initially
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Initial")
+        subprocess.run(["git", "add", "CLAUDE.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add CLAUDE.md"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        # Modify CLAUDE.md (simulating memory-updater)
+        claude_md.write_text("# Updated by auto-memory")
+
+        result = trigger.auto_commit_claude_md(str(tmp_path))
+        assert result is True
+
+        # Verify commit was made
+        log = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "CLAUDE.md" in log.stdout
+        assert "[auto-memory]" in log.stdout
+
+    def test_noop_when_no_claude_md_changes(self, tmp_path):
+        """Returns False when no CLAUDE.md files are modified."""
+        self._init_git_repo(tmp_path)
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Clean")
+        subprocess.run(["git", "add", "CLAUDE.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add CLAUDE.md"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        result = trigger.auto_commit_claude_md(str(tmp_path))
+        assert result is False
+
+    def test_commit_message_format(self, tmp_path):
+        """Commit message matches expected format."""
+        self._init_git_repo(tmp_path)
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Initial")
+        subprocess.run(["git", "add", "CLAUDE.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add CLAUDE.md"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        claude_md.write_text("# Updated")
+
+        trigger.auto_commit_claude_md(str(tmp_path))
+
+        log = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert log.stdout.strip() == "chore: update CLAUDE.md [auto-memory]"
+
+    def test_only_commits_claude_md_files(self, tmp_path):
+        """Other modified files are not included in the commit."""
+        self._init_git_repo(tmp_path)
+        # Create and commit both files
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Initial")
+        other = tmp_path / "other.py"
+        other.write_text("# other")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        # Modify both
+        claude_md.write_text("# Updated")
+        other.write_text("# modified")
+
+        trigger.auto_commit_claude_md(str(tmp_path))
+
+        # other.py should still show as modified (not committed)
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "other.py" in status.stdout
+
+    def test_returns_false_on_git_failure(self, tmp_path):
+        """Returns False when not in a git repo (graceful failure)."""
+        # tmp_path is not a git repo
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Not a repo")
+
+        result = trigger.auto_commit_claude_md(str(tmp_path))
+        assert result is False
+
+    def test_commits_subtree_claude_md(self, tmp_path):
+        """Commits CLAUDE.md files in subdirectories too."""
+        self._init_git_repo(tmp_path)
+        # Create root and subtree CLAUDE.md
+        root_md = tmp_path / "CLAUDE.md"
+        root_md.write_text("# Root")
+        sub_dir = tmp_path / "src"
+        sub_dir.mkdir()
+        sub_md = sub_dir / "CLAUDE.md"
+        sub_md.write_text("# Sub")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add CLAUDE.md files"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        # Modify both
+        root_md.write_text("# Root updated")
+        sub_md.write_text("# Sub updated")
+
+        result = trigger.auto_commit_claude_md(str(tmp_path))
+        assert result is True
+
+        # Both should be committed
+        show = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "CLAUDE.md" in show.stdout
+        assert "src/CLAUDE.md" in show.stdout
+
+
+class TestAutoPush:
+    """Tests for auto_push - pushes current branch to remote."""
+
+    def test_returns_false_on_push_failure(self, tmp_path):
+        """Returns False when push fails (no remote configured)."""
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        (tmp_path / ".gitkeep").write_text("")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+
+        result = trigger.auto_push(str(tmp_path))
+        assert result is False
+
+    def test_returns_false_when_not_git_repo(self, tmp_path):
+        """Returns False when not in a git repo."""
+        result = trigger.auto_push(str(tmp_path))
+        assert result is False


### PR DESCRIPTION
## Summary

- **Session isolation (#16)**: Uses `session_id` from hook stdin JSON to scope dirty-files to `dirty-files-{session_id}`, preventing cross-session interference in concurrent workflows. Falls back to plain `dirty-files` for backwards compatibility. Stale session files auto-cleaned after 24h.
- **Auto-commit/push (#18)**: New `autoCommit` and `autoPush` config options. When enabled, SubagentStop handler commits only CLAUDE.md files with message `chore: update CLAUDE.md [auto-memory]` and optionally pushes. Graceful failure on git errors.
- Bumps version to 0.9.0

Closes #16, closes #18

## Test plan

- [x] 31 new tests covering session-aware paths, stale cleanup, auto-commit, auto-push
- [x] All 162 tests passing (zero regressions)
- [x] Ruff lint and format clean
- [ ] Manual: Run `/auto-memory:init` on a test project, edit a file, verify `dirty-files-{session_id}` is created
- [ ] Manual: Set `"autoCommit": true` in config, let memory-updater run, verify git log shows auto-commit