### PR TITLE
Fix #31: detect glued shell-operator tokens in extract_files_from_bash

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-memory",
   "description": "Automatically maintains CLAUDE.md files as codebases evolve using hooks, agents, and skills",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "severity1"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 
 # Claude Code auto-memory
 .claude/auto-memory/dirty-files
+.claude/auto-memory/dirty-files-*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Configuration:
 - **Initialization Guard Pattern**: `plugin_initialized()` in post-tool-use.py, handle_stop(), and handle_pre_tool_use() gates all activity on config.json existence — projects that never ran /auto-memory:init are fully inert
 - **Hook Lifecycle Pattern**: PostToolUse tracks → Stop/PreToolUse blocks → Agent spawns → SubagentStop cleans up (cleanup gated on dirty-files only, not config.json, to prevent infinite loops)
 - **Separation of Concerns**: PostToolUse (silent tracking) vs Stop/PreToolUse (blocking with output) vs SubagentStop (cleanup)
-- **Dirty File Pattern**: Append-only tracking, batch processing at turn end, session-isolated via `dirty-files-{session_id}`
+- **Dirty File Pattern**: Dict-keyed deduplication (path as key), batch processing at turn end, session-isolated via `dirty-files-{session_id}`; commit context entries overwrite plain path entries when present
 - **Skill Pattern**: YAML frontmatter + markdown body with algorithm sections
 - **Template Pattern**: AUTO-MANAGED markers for updatable sections
 - **Config Pattern**: JSON config in `.claude/auto-memory/config.json` with `triggerMode`, `autoCommit`, `autoPush`
@@ -117,6 +117,8 @@ Configuration:
 - **Stale Session Cleanup Pattern**: `cleanup_stale_session_files()` removes orphaned session dirty-files older than 24h on each SubagentStop
 - **Dirty-Files Read Order**: memory-updater reads plain `dirty-files` first; checks session-specific `dirty-files-*` files only if plain file is empty or missing
 - **Gitignore Management Pattern**: `/auto-memory:init` appends `.claude/auto-memory/dirty-files*` to `.gitignore` (creates file if absent) so tracking files are never committed
+- **Bash Tracking Scope Pattern**: `extract_files_from_bash()` only tracks explicit file-destructive commands (rm, git rm, mv, git mv, unlink); all other Bash commands (read-only, build tools, package managers) are skipped; parser stops at shell operators (`&&`, `||`, `;`, `|`) and redirects
+- **Test Init Helper Pattern**: `_init_config(tmp_path)` creates `.claude/auto-memory/config.json` in tests to satisfy the `plugin_initialized()` guard; tests that verify inert behavior deliberately omit this call
 
 <!-- END AUTO-MANAGED -->
 

--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -183,10 +183,19 @@ def extract_files_from_bash(command: str, project_dir: str) -> list[str]:
     if command.startswith(skip_prefixes):
         return []
 
-    # Shell operators that chain commands - stop parsing at these
-    shell_operators = ("&&", "||", ";", "|", ">", ">>", "<", "2>", "2>&1")
+    def is_shell_op(token: str) -> bool:
+        """Return True if token is a pure shell operator or redirect."""
+        return token in {"&&", "||", ";", "|"} or token.startswith((">", "<", "2>", "1>", "&>"))
 
-    files = []
+    def process_token(token: str, files: list[str]) -> bool:
+        """Append token to files (stripping trailing semicolon) and return True to stop."""
+        stop = token.endswith(";")
+        clean = token[:-1] if stop else token
+        if clean and not clean.startswith("-"):
+            files.append(clean)
+        return stop
+
+    files: list[str] = []
 
     try:
         # Parse command into tokens
@@ -200,42 +209,47 @@ def extract_files_from_bash(command: str, project_dir: str) -> list[str]:
         if cmd == "rm":
             # Skip flags, collect file arguments until shell operator
             for token in tokens[1:]:
-                if token in shell_operators:
+                if is_shell_op(token):
                     break  # Stop at command chaining operator
-                if not token.startswith("-"):
-                    files.append(token)
+                if process_token(token, files):
+                    break
 
         # Handle: git rm
         elif cmd == "git" and len(tokens) > 1 and tokens[1] == "rm":
             for token in tokens[2:]:
-                if token in shell_operators:
+                if is_shell_op(token):
                     break
-                if not token.startswith("-"):
-                    files.append(token)
+                if process_token(token, files):
+                    break
 
         # Handle: mv (track source file only)
         elif cmd == "mv" and len(tokens) >= 3:
             # Skip flags, get first non-flag arg (source)
             for token in tokens[1:]:
-                if token in shell_operators:
+                if is_shell_op(token):
                     break
                 if not token.startswith("-"):
-                    files.append(token)
+                    clean = token[:-1] if token.endswith(";") else token
+                    if clean:
+                        files.append(clean)
                     break  # Only track source, not destination
 
         # Handle: git mv (track source file only)
         elif cmd == "git" and len(tokens) > 2 and tokens[1] == "mv":
             for token in tokens[2:]:
-                if token in shell_operators:
+                if is_shell_op(token):
                     break
                 if not token.startswith("-"):
-                    files.append(token)
+                    clean = token[:-1] if token.endswith(";") else token
+                    if clean:
+                        files.append(clean)
                     break
 
         # Handle: unlink
         elif cmd == "unlink" and len(tokens) > 1:
-            if tokens[1] not in shell_operators:
-                files.append(tokens[1])
+            t = tokens[1]
+            if not is_shell_op(t):
+                files.append(t[:-1] if t.endswith(";") else t)
 
     except ValueError:
         # shlex.split failed (unbalanced quotes, etc.) - skip

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add scripts directory to path
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 
@@ -1036,3 +1038,178 @@ class TestGitCommitContext:
         assert "[" in content  # Context marker
         assert ":" in content  # hash: message separator
         assert "Add module" in content
+
+
+class TestExtractFilesFromBash:
+    """Unit tests for extract_files_from_bash() shell-operator detection."""
+
+    def setup_method(self):
+        sys.path.insert(0, str(SCRIPTS_DIR))
+        from importlib import import_module
+
+        self.mod = import_module("post-tool-use")
+        self.fn = self.mod.extract_files_from_bash
+
+    def teardown_method(self):
+        sys.path.pop(0)
+        sys.modules.pop("post-tool-use", None)
+
+    def _paths(self, *names: str) -> list[str]:
+        return [str(Path("/tmp") / n) for n in names]
+
+    # ── rm: redirect variants ────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd,expected_names",
+        [
+            # stderr redirect glued
+            ("rm foo.txt 2>/dev/null", ["foo.txt"]),
+            # stderr redirect then chained command
+            ("rm foo.txt 2>/dev/null; echo done", ["foo.txt"]),
+            # stdout redirect glued to path
+            ("rm foo.txt >log.txt", ["foo.txt"]),
+            # append redirect
+            ("rm foo.txt >>log.txt", ["foo.txt"]),
+            # explicit stdout redirect
+            ("rm foo.txt 1>/dev/null", ["foo.txt"]),
+            # both streams redirect
+            ("rm foo.txt &>/dev/null", ["foo.txt"]),
+            # stderr-to-stdout redirect token
+            ("rm foo.txt 2>&1", ["foo.txt"]),
+            # input redirect (unusual but should stop)
+            ("rm foo.txt <input.txt", ["foo.txt"]),
+        ],
+    )
+    def test_rm_stops_at_redirects(self, cmd, expected_names):
+        """rm: parsing stops at all redirect forms."""
+        assert self.fn(cmd, "/tmp") == self._paths(*expected_names)
+
+    # ── rm: chaining operators ───────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd,expected_names",
+        [
+            # && operator as standalone token
+            ("rm foo.txt && echo done", ["foo.txt"]),
+            # || operator as standalone token
+            ("rm foo.txt || true", ["foo.txt"]),
+            # pipe as standalone token
+            ("rm foo.txt | tee log.txt", ["foo.txt"]),
+            # semicolon as standalone token (whitespace-separated)
+            ("rm foo.txt ; ls -la", ["foo.txt"]),
+            # semicolon glued to filename
+            ("rm foo.txt; rm bar.txt", ["foo.txt"]),
+            # trailing semicolon only (no following command)
+            ("rm foo.txt;", ["foo.txt"]),
+        ],
+    )
+    def test_rm_stops_at_chain_operators(self, cmd, expected_names):
+        """rm: parsing stops at all command-chaining operators."""
+        assert self.fn(cmd, "/tmp") == self._paths(*expected_names)
+
+    # ── rm: multiple files and flags ─────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd,expected_names",
+        [
+            # multiple files, no operator
+            ("rm a.txt b.txt c.txt", ["a.txt", "b.txt", "c.txt"]),
+            # multiple files, redirect truncates list
+            ("rm a.txt b.txt 2>/dev/null", ["a.txt", "b.txt"]),
+            # flags before files
+            ("rm -rf build/ 2>/dev/null", ["build/"]),
+            # -f flag with redirect
+            ("rm -f old.py >>/dev/null", ["old.py"]),
+            # mixed flags and files
+            ("rm -rf src/ lib/ 2>/dev/null", ["src/", "lib/"]),
+        ],
+    )
+    def test_rm_multiple_files_and_flags(self, cmd, expected_names):
+        """rm: flags are skipped; multiple files collected until operator."""
+        assert self.fn(cmd, "/tmp") == self._paths(*expected_names)
+
+    # ── git rm ───────────────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd,expected_names",
+        [
+            ("git rm foo.txt", ["foo.txt"]),
+            ("git rm foo.txt 2>/dev/null", ["foo.txt"]),
+            ("git rm foo.txt && git add bar.txt", ["foo.txt"]),
+            ("git rm foo.txt; echo done", ["foo.txt"]),
+            ("git rm -r dir/ 2>/dev/null", ["dir/"]),
+            ("git rm foo.txt bar.txt", ["foo.txt", "bar.txt"]),
+        ],
+    )
+    def test_git_rm_operator_detection(self, cmd, expected_names):
+        """git rm: all operator shapes stop parsing correctly."""
+        assert self.fn(cmd, "/tmp") == self._paths(*expected_names)
+
+    # ── mv ───────────────────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd,expected_names",
+        [
+            # basic: only source tracked
+            ("mv old.py new.py", ["old.py"]),
+            # redirect after destination: only source tracked
+            ("mv old.py new.py 2>/dev/null", ["old.py"]),
+            # chained after mv: only source tracked
+            ("mv old.py new.py && echo ok", ["old.py"]),
+            # semicolon glued to source
+            ("mv old.py; new.py", ["old.py"]),
+            # flag before source
+            ("mv -f old.py new.py", ["old.py"]),
+        ],
+    )
+    def test_mv_tracks_source_only(self, cmd, expected_names):
+        """mv: only the source file is tracked; operators stop parsing."""
+        assert self.fn(cmd, "/tmp") == self._paths(*expected_names)
+
+    # ── git mv ───────────────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd,expected_names",
+        [
+            ("git mv old.py new.py", ["old.py"]),
+            ("git mv old.py new.py 2>/dev/null", ["old.py"]),
+            ("git mv old.py new.py && git add .", ["old.py"]),
+            ("git mv -f old.py new.py", ["old.py"]),
+        ],
+    )
+    def test_git_mv_tracks_source_only(self, cmd, expected_names):
+        """git mv: only the source file is tracked; operators stop parsing."""
+        assert self.fn(cmd, "/tmp") == self._paths(*expected_names)
+
+    # ── unlink ───────────────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd,expected_names",
+        [
+            ("unlink foo.txt", ["foo.txt"]),
+            ("unlink foo.txt 2>/dev/null", ["foo.txt"]),
+            ("unlink foo.txt;", ["foo.txt"]),
+            ("unlink foo.txt && echo done", ["foo.txt"]),
+        ],
+    )
+    def test_unlink_operator_detection(self, cmd, expected_names):
+        """unlink: operator-adjacent tokens are stripped or stop parsing."""
+        assert self.fn(cmd, "/tmp") == self._paths(*expected_names)
+
+    # ── edge cases ───────────────────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "",
+            "   ",
+            "rm",
+            "rm -rf",
+            "git rm",
+            "mv",
+            "unlink",
+        ],
+    )
+    def test_returns_empty_for_degenerate_inputs(self, cmd):
+        """Degenerate inputs (empty, flags only, missing args) return []."""
+        assert self.fn(cmd, "/tmp") == []


### PR DESCRIPTION
## Summary

- `shlex.split()` does not split redirect/semicolon tokens glued to adjacent text (e.g. `2>/dev/null`, `foo.txt;`), so the previous exact-match check against `shell_operators` never fired for those forms
- Garbage entries like `/project/2>/dev/null` and `/project/echo` leaked into dirty-files, causing false Stop-hook triggers and confusing model context
- Fixes `extract_files_from_bash()` with two helpers: `is_shell_op()` (prefix-attached redirects) and `process_token()` (trailing-semicolon strip-and-stop)
- Adds 45 parametrized unit tests; total test count: 207 (up from 162)

## Test plan

- [x] `uv run pytest tests/ -v` - 207 passed
- [x] `uv run ruff check .` - no issues
- [x] `uv run ruff format --check .` - no issues
- [x] `uv run mypy scripts/` - no issues

Closes #31