### PR TITLE
feat: add AGENTS.md support (#14)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-memory",
   "description": "Automatically maintains CLAUDE.md files as codebases evolve using hooks, agents, and skills",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": {
     "name": "severity1"
   },

--- a/agents/memory-updater.md
+++ b/agents/memory-updater.md
@@ -5,7 +5,7 @@ model: sonnet
 permissionMode: bypassPermissions
 ---
 
-You are the memory-updater agent. Your job is to gather context about file changes and invoke the memory-processor skill to update CLAUDE.md.
+You are the memory-updater agent. Your job is to gather context about file changes and invoke the memory-processor skill to update the active memory file (CLAUDE.md or AGENTS.md, depending on project config).
 
 ## Workflow
 
@@ -38,10 +38,13 @@ For each changed file (max 7 files total):
    - This provides semantic context for why files changed
 4. If not git: skip this phase, note in summary
 
-### Phase 4: Discover CLAUDE.md Files
-1. Find all CLAUDE.md files: `fd -t f -g 'CLAUDE.md' .` (or `find . -name 'CLAUDE.md'`)
-2. Map each changed file to its nearest CLAUDE.md (walk up directories)
-3. Always include root CLAUDE.md
+### Phase 4: Discover Memory Files
+1. Read `.claude/auto-memory/config.json` to determine the active memory file:
+   - If `memoryFiles` contains `"AGENTS.md"` (or is `["AGENTS.md"]`): active file is `AGENTS.md`
+   - Otherwise (default): active file is `CLAUDE.md`
+2. Find all instances of the active file: `fd -t f -g '<active-file>' .` (or `find . -name '<active-file>'`)
+3. Map each changed file to its nearest instance (walk up directories)
+4. Always include the root instance of the active file
 
 ### Phase 5: Invoke Processor
 1. Invoke the `memory-processor` skill using Skill tool
@@ -52,7 +55,7 @@ For each changed file (max 7 files total):
    - Git context (commits, diffs)
    - CLAUDE.md files to update
 3. Return summary:
-   - "Updated [sections] in [CLAUDE.md files]"
+   - "Updated [sections] in [memory file paths]"
    - "Based on changes to [file list]"
    - If commit context was present: "From commit [hash]: [message]"
    - Note any errors or skipped items

--- a/commands/init.md
+++ b/commands/init.md
@@ -23,6 +23,24 @@ Save the selection to `.claude/auto-memory/config.json`:
 }
 ```
 
+### Step 1a: Configure Memory File(s)
+
+Ask the user which memory file(s) auto-memory should maintain using AskUserQuestion:
+
+**Question**: "Which memory file(s) should auto-memory maintain?"
+
+**Options**:
+- **CLAUDE.md only** (default): Standard Claude Code memory file. Best for projects using Claude Code exclusively.
+- **AGENTS.md only**: Memory stored in AGENTS.md. Best for projects using OpenAI Codex, Gemini, or other agents that read AGENTS.md.
+- **Both - AGENTS.md for content, CLAUDE.md redirects to it**: AGENTS.md holds full memory; CLAUDE.md contains a one-line redirect. Best when multiple AI coding agents collaborate on the same repo.
+
+Update `.claude/auto-memory/config.json` with the selection:
+- CLAUDE.md only: omit `memoryFiles` (or set `"memoryFiles": ["CLAUDE.md"]`)
+- AGENTS.md only: `"memoryFiles": ["AGENTS.md"]`
+- Both: `"memoryFiles": ["CLAUDE.md", "AGENTS.md"]`
+
+When "Both" is selected, also generate the redirect `CLAUDE.md` at the project root using the `CLAUDE.redirect.md.template` - a static file with the single line: `Read AGENTS.md in this directory for project context.`
+
 ### Step 1b: Configure Auto-Commit (Optional)
 
 Ask the user if they want CLAUDE.md changes auto-committed using AskUserQuestion:
@@ -30,8 +48,8 @@ Ask the user if they want CLAUDE.md changes auto-committed using AskUserQuestion
 **Question**: "Should auto-memory automatically commit CLAUDE.md changes after updates?"
 
 **Options**:
-- **No** (default): CLAUDE.md changes remain as local modifications. You commit them manually.
-- **Yes**: Automatically commit CLAUDE.md files after each memory update. Commit message: `chore: update CLAUDE.md [auto-memory]`
+- **No** (default): Memory file changes remain as local modifications. You commit them manually.
+- **Yes**: Automatically commit memory files after each memory update. Commit message: `chore: update CLAUDE.md [auto-memory]` (or `chore: update memory files [auto-memory]` when AGENTS.md is involved)
 
 If the user selects Yes, also ask about auto-push:
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -2,12 +2,13 @@
 description: Show CLAUDE.md memory sync status
 ---
 
-Display the current status of CLAUDE.md memory synchronization.
+Display the current status of memory file synchronization.
 
 Check and report:
 1. **Pending changes**: Count of files in `.claude/auto-memory/dirty-files` (or session-specific `dirty-files-*` files) awaiting processing
-2. **Last sync**: Modification timestamp of CLAUDE.md
-3. **CLAUDE.md locations**: All CLAUDE.md files found in the project
-4. **Configuration**: Current trigger mode, autoCommit, and autoPush settings from `.claude/auto-memory/config.json`
+2. **Active memory file**: Determined from `memoryFiles` in `.claude/auto-memory/config.json` - AGENTS.md if present in the list, otherwise CLAUDE.md
+3. **Last sync**: Modification timestamp of the active memory file
+4. **Memory file locations**: All instances of the active memory file found in the project (search by the active file name)
+5. **Configuration**: Current trigger mode, memoryFiles, autoCommit, and autoPush settings from `.claude/auto-memory/config.json`
 
 If there are pending changes, offer to run `/auto-memory:calibrate` to process them.

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -20,7 +20,7 @@ Use this when you've edited files manually (outside Claude Code) and want to upd
 
 3. **Filter files** (exclude from processing):
    - Files in `.claude/` directory
-   - `CLAUDE.md` files
+   - Memory files: read `memoryFiles` from `.claude/auto-memory/config.json` (default `["CLAUDE.md"]`) and exclude any file whose name appears in that list
    - Files outside project directory
 
 4. **If no changes detected**: Report "Already in sync - no manual changes found"
@@ -29,7 +29,7 @@ Use this when you've edited files manually (outside Claude Code) and want to upd
    - Convert paths to absolute paths
    - Write to `.claude/auto-memory/dirty-files` (one path per line, or `dirty-files-{session_id}` if session_id is available from the environment)
    - Use the Task tool to spawn the `memory-updater` agent with prompt:
-     "Update CLAUDE.md for manually changed files: [file list]"
+     "Update [active memory file] for manually changed files: [file list]" (use AGENTS.md or CLAUDE.md per the memoryFiles config)
 
 6. **Report summary**: List files that were processed
 

--- a/scripts/post-tool-use.py
+++ b/scripts/post-tool-use.py
@@ -50,6 +50,14 @@ def load_config(project_dir: str) -> dict[str, Any]:
     return {"triggerMode": "default"}
 
 
+def get_memory_files(config: dict[str, Any]) -> list[str]:
+    """Return the list of memory file names from config, defaulting to CLAUDE.md."""
+    v = config.get("memoryFiles", ["CLAUDE.md"])
+    if isinstance(v, str):
+        return [v]
+    return v if v else ["CLAUDE.md"]
+
+
 def handle_git_commit(project_dir: str) -> tuple[list[str], dict[str, str] | None]:
     """Extract context from a git commit.
 
@@ -95,8 +103,8 @@ def dirty_file_path(project_dir: str, session_id: str = "") -> Path:
     return base / "dirty-files"
 
 
-def should_track(file_path: str, project_dir: str) -> bool:
-    """Check if file should be tracked for CLAUDE.md updates."""
+def should_track(file_path: str, project_dir: str, memory_files: list[str] | None = None) -> bool:
+    """Check if file should be tracked for memory file updates."""
     path = Path(file_path)
 
     # Only track files within the project directory
@@ -109,8 +117,9 @@ def should_track(file_path: str, project_dir: str) -> bool:
     if relative.parts and relative.parts[0] == ".claude":
         return False
 
-    # Exclude CLAUDE.md files anywhere (prevents infinite loops)
-    if path.name == "CLAUDE.md":
+    # Exclude memory files anywhere (prevents infinite loops when they are updated)
+    names = memory_files if memory_files is not None else ["CLAUDE.md"]
+    if path.name in names:
         return False
 
     return True
@@ -337,7 +346,8 @@ def main() -> None:
         return
 
     # Filter to only trackable files
-    trackable = [f for f in files_to_track if should_track(f, project_dir)]
+    memory_files = get_memory_files(config)
+    trackable = [f for f in files_to_track if should_track(f, project_dir, memory_files)]
 
     if not trackable:
         return

--- a/scripts/trigger.py
+++ b/scripts/trigger.py
@@ -48,6 +48,19 @@ def load_config(project_dir: str) -> dict[str, Any]:
     return {"triggerMode": "default"}
 
 
+def get_memory_files(config: dict[str, Any]) -> list[str]:
+    """Return the list of memory file names from config, defaulting to CLAUDE.md."""
+    v = config.get("memoryFiles", ["CLAUDE.md"])
+    if isinstance(v, str):
+        return [v]
+    return v if v else ["CLAUDE.md"]
+
+
+def get_active_memory_file(memory_files: list[str]) -> str:
+    """Return the file that receives full content. AGENTS.md wins when both are configured."""
+    return "AGENTS.md" if "AGENTS.md" in memory_files else "CLAUDE.md"
+
+
 def dirty_file_path(project_dir: str, session_id: str = "") -> Path:
     """Return path to session-specific or default dirty-files."""
     base = Path(project_dir) / ".claude" / "auto-memory"
@@ -80,16 +93,17 @@ def read_dirty_files(project_dir: str, session_id: str = "") -> list[str]:
     return sorted(files)[:20]
 
 
-def build_spawn_reason(files: list[str]) -> str:
+def build_spawn_reason(files: list[str], config: dict[str, Any] | None = None) -> str:
     """Build the agent spawn instruction text with Task tool parameters."""
     files_str = ", ".join(files)
+    active = get_active_memory_file(get_memory_files(config or {}))
     return (
         f"Files were modified this turn. Use the Task tool with "
         f"run_in_background set to false and mode set to bypassPermissions "
         f"to spawn 'memory-updater' agent with subagent_type set to "
-        f"'auto-memory:memory-updater' and prompt: 'Update CLAUDE.md for "
+        f"'auto-memory:memory-updater' and prompt: 'Update {active} for "
         f"changed files: {files_str}'. After the agent completes, use the "
-        f"Read tool to read the root CLAUDE.md file to refresh your memory."
+        f"Read tool to read the root {active} file to refresh your memory."
     )
 
 
@@ -121,7 +135,7 @@ def handle_stop(input_data: dict[str, Any], project_dir: str) -> None:
 
     output = {
         "decision": "block",
-        "reason": build_spawn_reason(files),
+        "reason": build_spawn_reason(files, config),
     }
     print(json.dumps(output))
 
@@ -152,9 +166,11 @@ def cleanup_stale_session_files(project_dir: str, max_age_hours: int = 24) -> No
             pass
 
 
-def auto_commit_claude_md(project_dir: str) -> bool:
-    """Stage and commit modified CLAUDE.md files. Returns True on success."""
-    # Find modified CLAUDE.md files (tracked, unstaged changes)
+def auto_commit_memory_files(project_dir: str, config: dict[str, Any]) -> bool:
+    """Stage and commit modified memory files (CLAUDE.md, AGENTS.md). Returns True on success."""
+    memory_files = get_memory_files(config)
+
+    # Find modified tracked files
     result = subprocess.run(
         ["git", "diff", "--name-only", "--diff-filter=M"],
         capture_output=True,
@@ -164,17 +180,17 @@ def auto_commit_claude_md(project_dir: str) -> bool:
     if result.returncode != 0:
         return False
 
-    claude_files = [
+    matched = [
         f.strip()
         for f in result.stdout.strip().split("\n")
-        if f.strip() and f.strip().endswith("CLAUDE.md")
+        if f.strip() and any(f.strip().endswith(name) for name in memory_files)
     ]
-    if not claude_files:
+    if not matched:
         return False
 
-    # Stage only CLAUDE.md files
+    # Stage only the matched memory files
     stage = subprocess.run(
-        ["git", "add"] + claude_files,
+        ["git", "add"] + matched,
         capture_output=True,
         text=True,
         cwd=project_dir,
@@ -182,9 +198,14 @@ def auto_commit_claude_md(project_dir: str) -> bool:
     if stage.returncode != 0:
         return False
 
-    # Commit
+    # Commit message reflects which files are managed
+    if memory_files == ["CLAUDE.md"]:
+        msg = "chore: update CLAUDE.md [auto-memory]"
+    else:
+        msg = "chore: update memory files [auto-memory]"
+
     commit = subprocess.run(
-        ["git", "commit", "-m", "chore: update CLAUDE.md [auto-memory]"],
+        ["git", "commit", "-m", msg],
         capture_output=True,
         text=True,
         cwd=project_dir,
@@ -223,7 +244,7 @@ def handle_subagent_stop(input_data: dict[str, Any], project_dir: str) -> None:
     # Auto-commit/push before clearing dirty files
     config = load_config(project_dir)
     if config.get("autoCommit", False):
-        if auto_commit_claude_md(project_dir):
+        if auto_commit_memory_files(project_dir, config):
             if config.get("autoPush", False):
                 auto_push(project_dir)
 
@@ -259,6 +280,7 @@ def handle_pre_tool_use(input_data: dict[str, Any], project_dir: str) -> None:
     if not files:
         return
 
+    active = get_active_memory_file(get_memory_files(config))
     files_str = ", ".join(files)
     output = {
         "hookSpecificOutput": {
@@ -268,7 +290,7 @@ def handle_pre_tool_use(input_data: dict[str, Any], project_dir: str) -> None:
                 f"Files were modified since last memory update. Use the Task tool "
                 f"with run_in_background set to false and mode set to "
                 f"bypassPermissions to spawn 'memory-updater' agent with subagent_type "
-                f"set to 'auto-memory:memory-updater' and prompt: 'Update CLAUDE.md "
+                f"set to 'auto-memory:memory-updater' and prompt: 'Update {active} "
                 f"for changed files: {files_str}'. After the agent completes, retry "
                 f"the git commit."
             ),

--- a/skills/codebase-analyzer/SKILL.md
+++ b/skills/codebase-analyzer/SKILL.md
@@ -65,16 +65,28 @@ Use AskUserQuestion to confirm:
 - Suggested subtree locations
 - Detected patterns
 
-### 7. Generate CLAUDE.md
+### 7. Generate Memory Files
 
-Generate files using the EXACT template structure. Follow these steps precisely:
+Read `.claude/auto-memory/config.json` to determine which files to generate based on `memoryFiles`:
 
-1. **Copy template skeleton** - Use template file as the base structure
+| `memoryFiles` value | Files to generate |
+|---|---|
+| absent or `["CLAUDE.md"]` | `CLAUDE.md` only (full content) |
+| `["AGENTS.md"]` | `AGENTS.md` only (full content) |
+| `["CLAUDE.md", "AGENTS.md"]` | `AGENTS.md` (full content) + `CLAUDE.md` (redirect) |
+
+Generate full-content files using the EXACT template structure. Follow these steps precisely:
+
+1. **Copy template skeleton** - Use the appropriate template (CLAUDE or AGENTS) as the base structure
 2. **Use exact marker format** - See Marker Syntax section below
 3. **Replace placeholders** - Substitute `{{PLACEHOLDER}}` with detected content
 4. **Include all required sections** - Even if content is minimal, include the section
 5. **Add MANUAL section** at the end for user notes
 6. **Size limits**: Root 150-200 lines, Subtrees 50-75 lines
+
+When both `CLAUDE.md` and `AGENTS.md` are configured, also generate redirect files:
+- At the root: write `CLAUDE.md` using `CLAUDE.redirect.md.template` (static pointer, no markers)
+- For each subtree that gets an `AGENTS.md`: write a matching `CLAUDE.md` redirect alongside it
 
 ## Marker Syntax
 
@@ -136,11 +148,20 @@ Generate these sections in order:
 
 Reference the template files for exact structure:
 
-### Root Template
+### CLAUDE.md Root Template
 @templates/CLAUDE.root.md.template
 
-### Subtree Template
+### CLAUDE.md Subtree Template
 @templates/CLAUDE.subtree.md.template
+
+### AGENTS.md Root Template
+@templates/AGENTS.root.md.template
+
+### AGENTS.md Subtree Template
+@templates/AGENTS.subtree.md.template
+
+### CLAUDE.md Redirect Template (when both files configured)
+@templates/CLAUDE.redirect.md.template
 
 ## User Interactions
 

--- a/skills/codebase-analyzer/templates/AGENTS.root.md.template
+++ b/skills/codebase-analyzer/templates/AGENTS.root.md.template
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+<!-- AUTO-MANAGED: project-description -->
+## Overview
+
+{{DESCRIPTION}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: build-commands -->
+## Build & Development Commands
+
+{{BUILD_COMMANDS}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: architecture -->
+## Architecture
+
+{{ARCHITECTURE}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: conventions -->
+## Code Conventions
+
+{{CONVENTIONS}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: patterns -->
+## Detected Patterns
+
+{{PATTERNS}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: git-insights -->
+## Git Insights
+
+{{GIT_INSIGHTS}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: best-practices -->
+## Best Practices
+
+{{BEST_PRACTICES}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- MANUAL -->
+## Custom Notes
+
+Add project-specific notes here. This section is never auto-modified.
+
+<!-- END MANUAL -->

--- a/skills/codebase-analyzer/templates/AGENTS.subtree.md.template
+++ b/skills/codebase-analyzer/templates/AGENTS.subtree.md.template
@@ -1,0 +1,34 @@
+# Module: {{MODULE_NAME}}
+
+<!-- AUTO-MANAGED: module-description -->
+## Purpose
+
+{{DESCRIPTION}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: architecture -->
+## Module Architecture
+
+{{ARCHITECTURE}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: conventions -->
+## Module-Specific Conventions
+
+{{CONVENTIONS}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: dependencies -->
+## Key Dependencies
+
+{{DEPENDENCIES}}
+
+<!-- END AUTO-MANAGED -->
+
+<!-- MANUAL -->
+## Notes
+
+<!-- END MANUAL -->

--- a/skills/codebase-analyzer/templates/CLAUDE.redirect.md.template
+++ b/skills/codebase-analyzer/templates/CLAUDE.redirect.md.template
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Read AGENTS.md in this directory for project context.

--- a/skills/memory-processor/SKILL.md
+++ b/skills/memory-processor/SKILL.md
@@ -5,7 +5,7 @@ description: Process file changes and update CLAUDE.md memory sections. Use when
 
 # Memory Processor
 
-Process changed files and update relevant CLAUDE.md sections following official guidelines.
+Process changed files and update relevant memory file sections (CLAUDE.md or AGENTS.md, whichever is the active file per project config) following official guidelines.
 
 ## Guidelines
 
@@ -20,7 +20,7 @@ Process changed files and update relevant CLAUDE.md sections following official 
    - File content summaries
    - Detected dependencies
    - Git context (commits, diffs)
-   - Target CLAUDE.md files
+   - Target memory files (CLAUDE.md or AGENTS.md per project config)
 
 2. **Categorize changes**: Map files to CLAUDE.md sections using the tables in "Section Names" below. Match changed files to their update triggers.
 
@@ -59,10 +59,11 @@ Process changed files and update relevant CLAUDE.md sections following official 
    - Architecture: `utils/` directory deleted → verify no `utils/` references remain
    - Build command: `npm run dev` removed from package.json → verify script is gone
 
-5. **Update CLAUDE.md**: Modify relevant sections:
+5. **Update memory file**: Modify relevant sections in the active memory file:
    - Preserve AUTO-MANAGED markers
    - Never touch MANUAL sections
    - Apply content rules (specific, concise, structured)
+   - Do not modify CLAUDE.md redirect files (files containing only "Read AGENTS.md...")
 
 6. **Validate**: Ensure updates follow guidelines:
    - No generic instructions added
@@ -115,6 +116,6 @@ Content that will never be touched
 ## Output
 
 Return a brief summary:
-- "Updated [section names] in [CLAUDE.md path] based on changes to [file names]"
+- "Updated [section names] in [memory file path] based on changes to [file names]"
 - "Removed [pattern] from [section] - no longer used in codebase"
 - "No updates needed - changes do not affect documented sections"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -419,6 +419,64 @@ class TestPostToolUseHook:
         plain_dirty = tmp_path / ".claude" / "auto-memory" / "dirty-files"
         assert not plain_dirty.exists()
 
+    def test_does_not_track_agents_md_edit(self, tmp_path):
+        """AGENTS.md edits are not tracked when it is a configured memory file."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.json").write_text(
+            json.dumps({"triggerMode": "default", "memoryFiles": ["AGENTS.md"]})
+        )
+        file_path = str(tmp_path / "AGENTS.md")
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
+            env={**os.environ, **env},
+            input=self._make_tool_input(file_path),
+            capture_output=True,
+            text=True,
+        )
+        dirty_file = config_dir / "dirty-files"
+        assert not dirty_file.exists()
+
+    def test_does_not_track_either_memory_file_when_both(self, tmp_path):
+        """Neither CLAUDE.md nor AGENTS.md is tracked when both are configured."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.json").write_text(
+            json.dumps({"triggerMode": "default", "memoryFiles": ["CLAUDE.md", "AGENTS.md"]})
+        )
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        for filename in ("CLAUDE.md", "AGENTS.md"):
+            subprocess.run(
+                [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
+                env={**os.environ, **env},
+                input=self._make_tool_input(str(tmp_path / filename)),
+                capture_output=True,
+                text=True,
+            )
+        dirty_file = config_dir / "dirty-files"
+        assert not dirty_file.exists()
+
+    def test_tracks_source_file_with_agents_only_config(self, tmp_path):
+        """Non-memory files are still tracked when memoryFiles is set to AGENTS.md."""
+        config_dir = tmp_path / ".claude" / "auto-memory"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.json").write_text(
+            json.dumps({"triggerMode": "default", "memoryFiles": ["AGENTS.md"]})
+        )
+        file_path = str(tmp_path / "src" / "main.py")
+        env = {"CLAUDE_PROJECT_DIR": str(tmp_path)}
+        subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "post-tool-use.py"],
+            env={**os.environ, **env},
+            input=self._make_tool_input(file_path),
+            capture_output=True,
+            text=True,
+        )
+        dirty_file = config_dir / "dirty-files"
+        assert dirty_file.exists()
+        assert "main.py" in dirty_file.read_text()
+
     def test_falls_back_to_plain_dirty_file(self, tmp_path):
         """Without session_id, writes to plain dirty-files."""
         self._init_config(tmp_path)
@@ -1213,3 +1271,50 @@ class TestExtractFilesFromBash:
     def test_returns_empty_for_degenerate_inputs(self, cmd):
         """Degenerate inputs (empty, flags only, missing args) return []."""
         assert self.fn(cmd, "/tmp") == []
+
+
+class TestShouldTrack:
+    """Unit tests for should_track() memory-file exclusion with configurable memoryFiles."""
+
+    def setup_method(self):
+        sys.path.insert(0, str(SCRIPTS_DIR))
+        from importlib import import_module
+
+        self.mod = import_module("post-tool-use")
+        self.fn = self.mod.should_track
+
+    def teardown_method(self):
+        sys.path.pop(0)
+        sys.modules.pop("post-tool-use", None)
+
+    def test_default_still_excludes_claude_md(self, tmp_path):
+        """CLAUDE.md is excluded by default (no memoryFiles in config)."""
+        assert self.fn(str(tmp_path / "CLAUDE.md"), str(tmp_path)) is False
+
+    def test_excludes_agents_md_when_configured(self, tmp_path):
+        """AGENTS.md is excluded when memoryFiles includes it."""
+        assert self.fn(str(tmp_path / "AGENTS.md"), str(tmp_path), ["AGENTS.md"]) is False
+
+    def test_excludes_claude_md_when_both_configured(self, tmp_path):
+        """CLAUDE.md is excluded when both files are configured."""
+        assert (
+            self.fn(str(tmp_path / "CLAUDE.md"), str(tmp_path), ["CLAUDE.md", "AGENTS.md"]) is False
+        )
+
+    def test_excludes_agents_md_when_both_configured(self, tmp_path):
+        """AGENTS.md is excluded when both files are configured."""
+        assert (
+            self.fn(str(tmp_path / "AGENTS.md"), str(tmp_path), ["CLAUDE.md", "AGENTS.md"]) is False
+        )
+
+    def test_does_not_exclude_agents_py(self, tmp_path):
+        """AGENTS.py is not excluded - only the exact memory file names are filtered."""
+        assert self.fn(str(tmp_path / "agents.py"), str(tmp_path), ["AGENTS.md"]) is True
+
+    def test_does_not_exclude_claude_when_agents_only(self, tmp_path):
+        """CLAUDE.md is tracked when memoryFiles is set to AGENTS.md only."""
+        assert self.fn(str(tmp_path / "CLAUDE.md"), str(tmp_path), ["AGENTS.md"]) is True
+
+    def test_regular_file_still_tracked(self, tmp_path):
+        """Regular source files are always tracked."""
+        assert self.fn(str(tmp_path / "src" / "main.py"), str(tmp_path)) is True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -215,3 +215,29 @@ class TestFileStructure:
     def test_dev_marketplace_exists(self):
         """.dev-marketplace directory exists for local development."""
         assert (PROJECT_ROOT / ".dev-marketplace" / ".claude-plugin" / "marketplace.json").exists()
+
+    def test_agents_root_template_exists(self):
+        """AGENTS.root.md.template exists for AGENTS.md support (#14)."""
+        assert (
+            PROJECT_ROOT / "skills" / "codebase-analyzer" / "templates" / "AGENTS.root.md.template"
+        ).exists()
+
+    def test_agents_subtree_template_exists(self):
+        """AGENTS.subtree.md.template exists for AGENTS.md support (#14)."""
+        assert (
+            PROJECT_ROOT
+            / "skills"
+            / "codebase-analyzer"
+            / "templates"
+            / "AGENTS.subtree.md.template"
+        ).exists()
+
+    def test_claude_redirect_template_exists(self):
+        """CLAUDE.redirect.md.template exists for redirect mode (#14)."""
+        assert (
+            PROJECT_ROOT
+            / "skills"
+            / "codebase-analyzer"
+            / "templates"
+            / "CLAUDE.redirect.md.template"
+        ).exists()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -168,3 +168,70 @@ class TestTemplates:
         lines = content.split("\n")
         # Template should be under 50 lines
         assert len(lines) < 50
+
+
+class TestAgentsMdTemplates:
+    """Tests for AGENTS.md templates (#14 - AGENTS.md support)."""
+
+    @pytest.fixture
+    def templates_dir(self):
+        return SKILLS_DIR / "codebase-analyzer" / "templates"
+
+    @pytest.fixture
+    def agents_root(self, templates_dir):
+        return templates_dir / "AGENTS.root.md.template"
+
+    @pytest.fixture
+    def agents_subtree(self, templates_dir):
+        return templates_dir / "AGENTS.subtree.md.template"
+
+    @pytest.fixture
+    def claude_redirect(self, templates_dir):
+        return templates_dir / "CLAUDE.redirect.md.template"
+
+    def test_agents_root_template_exists(self, agents_root):
+        """AGENTS.root.md.template exists."""
+        assert agents_root.exists()
+
+    def test_agents_subtree_template_exists(self, agents_subtree):
+        """AGENTS.subtree.md.template exists."""
+        assert agents_subtree.exists()
+
+    def test_claude_redirect_template_exists(self, claude_redirect):
+        """CLAUDE.redirect.md.template exists."""
+        assert claude_redirect.exists()
+
+    def test_agents_root_has_markers(self, agents_root):
+        """AGENTS root template has AUTO-MANAGED markers."""
+        content = agents_root.read_text()
+        assert "<!-- AUTO-MANAGED:" in content
+        assert "<!-- END AUTO-MANAGED -->" in content
+
+    def test_agents_root_has_manual_section(self, agents_root):
+        """AGENTS root template has MANUAL section."""
+        content = agents_root.read_text()
+        assert "<!-- MANUAL -->" in content
+        assert "<!-- END MANUAL -->" in content
+
+    def test_agents_root_has_placeholders(self, agents_root):
+        """AGENTS root template has {{PLACEHOLDER}} tokens."""
+        content = agents_root.read_text()
+        placeholders = re.findall(r"\{\{(\w+)\}\}", content)
+        assert "DESCRIPTION" in placeholders
+        assert "BUILD_COMMANDS" in placeholders
+
+    def test_agents_subtree_has_markers(self, agents_subtree):
+        """AGENTS subtree template has AUTO-MANAGED markers."""
+        content = agents_subtree.read_text()
+        assert "<!-- AUTO-MANAGED:" in content
+        assert "<!-- END AUTO-MANAGED -->" in content
+
+    def test_claude_redirect_has_redirect_text(self, claude_redirect):
+        """CLAUDE.redirect template contains the AGENTS.md redirect instruction."""
+        content = claude_redirect.read_text()
+        assert "Read AGENTS.md" in content
+
+    def test_claude_redirect_does_not_have_auto_managed_markers(self, claude_redirect):
+        """CLAUDE.redirect template is static - no AUTO-MANAGED markers."""
+        content = claude_redirect.read_text()
+        assert "<!-- AUTO-MANAGED:" not in content

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 # Make scripts/ importable so we can load trigger.py as a module.
@@ -18,6 +19,47 @@ SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 trigger = importlib.import_module("trigger")
 sys.path.pop(0)
+
+
+class TestGetMemoryFiles:
+    """Tests for get_memory_files - resolves configured memory file names."""
+
+    def test_returns_claude_md_when_key_absent(self):
+        """Defaults to ['CLAUDE.md'] when memoryFiles not in config."""
+        assert trigger.get_memory_files({}) == ["CLAUDE.md"]
+
+    def test_returns_claude_md_when_empty_list(self):
+        """Falls back to ['CLAUDE.md'] when memoryFiles is an empty list."""
+        assert trigger.get_memory_files({"memoryFiles": []}) == ["CLAUDE.md"]
+
+    def test_returns_list_as_is(self):
+        """Returns list unchanged when memoryFiles is already a list."""
+        assert trigger.get_memory_files({"memoryFiles": ["AGENTS.md"]}) == ["AGENTS.md"]
+
+    def test_returns_both_when_both(self):
+        """Returns both names when both are configured."""
+        result = trigger.get_memory_files({"memoryFiles": ["CLAUDE.md", "AGENTS.md"]})
+        assert result == ["CLAUDE.md", "AGENTS.md"]
+
+    def test_wraps_string_in_list(self):
+        """Wraps a bare string value in a list for backwards compatibility."""
+        assert trigger.get_memory_files({"memoryFiles": "CLAUDE.md"}) == ["CLAUDE.md"]
+
+
+class TestGetActiveMemoryFile:
+    """Tests for get_active_memory_file - selects the file that gets full content."""
+
+    def test_returns_agents_when_agents_present(self):
+        """AGENTS.md wins when only AGENTS.md configured."""
+        assert trigger.get_active_memory_file(["AGENTS.md"]) == "AGENTS.md"
+
+    def test_returns_agents_when_both(self):
+        """AGENTS.md wins when both CLAUDE.md and AGENTS.md configured."""
+        assert trigger.get_active_memory_file(["CLAUDE.md", "AGENTS.md"]) == "AGENTS.md"
+
+    def test_returns_claude_when_only_claude(self):
+        """CLAUDE.md returned when it is the only configured file."""
+        assert trigger.get_active_memory_file(["CLAUDE.md"]) == "CLAUDE.md"
 
 
 class TestDirtyFilePath:
@@ -242,6 +284,22 @@ class TestBuildSpawnReason:
         reason = trigger.build_spawn_reason(["/file.py"])
         assert "Read tool" in reason
         assert "CLAUDE.md" in reason
+
+    def test_prompt_references_active_file_claude(self):
+        """Without memoryFiles config, prompt references CLAUDE.md."""
+        reason = trigger.build_spawn_reason(["/file.py"], {})
+        assert "Update CLAUDE.md" in reason
+
+    def test_prompt_references_active_file_agents(self):
+        """With AGENTS.md configured, prompt references AGENTS.md."""
+        reason = trigger.build_spawn_reason(["/file.py"], {"memoryFiles": ["AGENTS.md"]})
+        assert "Update AGENTS.md" in reason
+
+    def test_read_instruction_references_active_file(self):
+        """With AGENTS.md configured, Read instruction mentions AGENTS.md."""
+        reason = trigger.build_spawn_reason(["/file.py"], {"memoryFiles": ["AGENTS.md"]})
+        assert "AGENTS.md" in reason
+        assert "Read tool" in reason
 
 
 class TestHandleStop:
@@ -691,8 +749,8 @@ class TestCleanupStaleSessions:
         # Should not raise
 
 
-class TestAutoCommitClaudeMd:
-    """Tests for auto_commit_claude_md - stages and commits CLAUDE.md files."""
+class TestAutoCommitMemoryFiles:
+    """Tests for auto_commit_memory_files - stages and commits memory files."""
 
     def _init_git_repo(self, tmp_path):
         """Initialize a git repo with an initial commit."""
@@ -731,7 +789,8 @@ class TestAutoCommitClaudeMd:
         # Modify CLAUDE.md (simulating memory-updater)
         claude_md.write_text("# Updated by auto-memory")
 
-        result = trigger.auto_commit_claude_md(str(tmp_path))
+        claude_config: dict[str, Any] = {"triggerMode": "default"}
+        result = trigger.auto_commit_memory_files(str(tmp_path), claude_config)
         assert result is True
 
         # Verify commit was made
@@ -756,11 +815,11 @@ class TestAutoCommitClaudeMd:
             capture_output=True,
         )
 
-        result = trigger.auto_commit_claude_md(str(tmp_path))
+        result = trigger.auto_commit_memory_files(str(tmp_path), {})
         assert result is False
 
     def test_commit_message_format(self, tmp_path):
-        """Commit message matches expected format."""
+        """Commit message is 'chore: update CLAUDE.md [auto-memory]' for default config."""
         self._init_git_repo(tmp_path)
         claude_md = tmp_path / "CLAUDE.md"
         claude_md.write_text("# Initial")
@@ -772,7 +831,7 @@ class TestAutoCommitClaudeMd:
         )
         claude_md.write_text("# Updated")
 
-        trigger.auto_commit_claude_md(str(tmp_path))
+        trigger.auto_commit_memory_files(str(tmp_path), {})
 
         log = subprocess.run(
             ["git", "log", "-1", "--format=%s"],
@@ -800,7 +859,7 @@ class TestAutoCommitClaudeMd:
         claude_md.write_text("# Updated")
         other.write_text("# modified")
 
-        trigger.auto_commit_claude_md(str(tmp_path))
+        trigger.auto_commit_memory_files(str(tmp_path), {})
 
         # other.py should still show as modified (not committed)
         status = subprocess.run(
@@ -817,7 +876,7 @@ class TestAutoCommitClaudeMd:
         claude_md = tmp_path / "CLAUDE.md"
         claude_md.write_text("# Not a repo")
 
-        result = trigger.auto_commit_claude_md(str(tmp_path))
+        result = trigger.auto_commit_memory_files(str(tmp_path), {})
         assert result is False
 
     def test_commits_subtree_claude_md(self, tmp_path):
@@ -840,7 +899,7 @@ class TestAutoCommitClaudeMd:
         root_md.write_text("# Root updated")
         sub_md.write_text("# Sub updated")
 
-        result = trigger.auto_commit_claude_md(str(tmp_path))
+        result = trigger.auto_commit_memory_files(str(tmp_path), {})
         assert result is True
 
         # Both should be committed
@@ -852,6 +911,146 @@ class TestAutoCommitClaudeMd:
         )
         assert "CLAUDE.md" in show.stdout
         assert "src/CLAUDE.md" in show.stdout
+
+    def test_commits_agents_md_when_configured(self, tmp_path):
+        """Commits AGENTS.md when memoryFiles is set to AGENTS.md."""
+        self._init_git_repo(tmp_path)
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text("# Initial")
+        subprocess.run(["git", "add", "AGENTS.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add AGENTS.md"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        agents_md.write_text("# Updated by auto-memory")
+
+        config: dict[str, Any] = {"memoryFiles": ["AGENTS.md"]}
+        result = trigger.auto_commit_memory_files(str(tmp_path), config)
+        assert result is True
+
+        show = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "AGENTS.md" in show.stdout
+
+    def test_commits_both_when_both_configured(self, tmp_path):
+        """Commits both CLAUDE.md and AGENTS.md in a single commit."""
+        self._init_git_repo(tmp_path)
+        (tmp_path / "CLAUDE.md").write_text("# Redirect")
+        (tmp_path / "AGENTS.md").write_text("# Initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add memory files"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        (tmp_path / "CLAUDE.md").write_text("# Redirect v2")
+        (tmp_path / "AGENTS.md").write_text("# Updated")
+
+        config = {"memoryFiles": ["CLAUDE.md", "AGENTS.md"]}
+        result = trigger.auto_commit_memory_files(str(tmp_path), config)
+        assert result is True
+
+        show = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "CLAUDE.md" in show.stdout
+        assert "AGENTS.md" in show.stdout
+
+    def test_does_not_commit_non_memory_file(self, tmp_path):
+        """CLAUDE.md is not committed when only AGENTS.md is configured."""
+        self._init_git_repo(tmp_path)
+        (tmp_path / "CLAUDE.md").write_text("# Read AGENTS.md")
+        (tmp_path / "AGENTS.md").write_text("# Initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        # Only CLAUDE.md modified; AGENTS.md not modified
+        (tmp_path / "CLAUDE.md").write_text("# Modified redirect")
+
+        config = {"memoryFiles": ["AGENTS.md"]}
+        result = trigger.auto_commit_memory_files(str(tmp_path), config)
+        assert result is False  # CLAUDE.md not in memoryFiles, nothing to commit
+
+    def test_commit_message_generic_when_agents_involved(self, tmp_path):
+        """Commit message is generic when AGENTS.md is in memoryFiles."""
+        self._init_git_repo(tmp_path)
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text("# Initial")
+        subprocess.run(["git", "add", "AGENTS.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add AGENTS.md"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        agents_md.write_text("# Updated")
+
+        trigger.auto_commit_memory_files(str(tmp_path), {"memoryFiles": ["AGENTS.md"]})
+
+        log = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert log.stdout.strip() == "chore: update memory files [auto-memory]"
+
+    def test_returns_false_when_no_matching_files_modified(self, tmp_path):
+        """Returns False when only non-configured memory files are modified."""
+        self._init_git_repo(tmp_path)
+        (tmp_path / "AGENTS.md").write_text("# Initial")
+        (tmp_path / "CLAUDE.md").write_text("# Initial")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add files"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        # Modify CLAUDE.md but config only tracks AGENTS.md
+        (tmp_path / "CLAUDE.md").write_text("# Modified")
+
+        result = trigger.auto_commit_memory_files(str(tmp_path), {"memoryFiles": ["AGENTS.md"]})
+        assert result is False
+
+    def test_commits_subtree_agents_md(self, tmp_path):
+        """Commits AGENTS.md files in subdirectories too."""
+        self._init_git_repo(tmp_path)
+        root_agents = tmp_path / "AGENTS.md"
+        root_agents.write_text("# Root")
+        sub_dir = tmp_path / "src"
+        sub_dir.mkdir()
+        sub_agents = sub_dir / "AGENTS.md"
+        sub_agents.write_text("# Sub")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add AGENTS.md files"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        root_agents.write_text("# Root updated")
+        sub_agents.write_text("# Sub updated")
+
+        result = trigger.auto_commit_memory_files(str(tmp_path), {"memoryFiles": ["AGENTS.md"]})
+        assert result is True
+
+        show = subprocess.run(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "AGENTS.md" in show.stdout
+        assert "src/AGENTS.md" in show.stdout
 
 
 class TestAutoPush:


### PR DESCRIPTION
## Summary

- Introduces `memoryFiles` config to control which memory file(s) auto-memory maintains
- Three modes: CLAUDE.md only (default, fully backwards-compatible), AGENTS.md only, or both (AGENTS.md full content + CLAUDE.md static redirect)
- All existing behaviour unchanged when `memoryFiles` is absent from config

## What changed

**Scripts**
- `post-tool-use.py`: `should_track()` now excludes all files named in `memoryFiles` (not just hardcoded `CLAUDE.md`)
- `trigger.py`: `get_memory_files()` / `get_active_memory_file()` helpers; `auto_commit_memory_files()` commits whichever files are configured; spawn reason and pre-tool-use deny message reference the active file by name

**Templates**
- `AGENTS.root.md.template` - same structure as CLAUDE root template
- `AGENTS.subtree.md.template` - same structure as CLAUDE subtree template
- `CLAUDE.redirect.md.template` - static one-line redirect used when both files configured

**Markdown docs**
- `agents/memory-updater.md`: Phase 4 reads config to discover the active memory file
- `skills/codebase-analyzer/SKILL.md`: Step 7 generates the correct file set per `memoryFiles` config, references new templates
- `skills/memory-processor/SKILL.md`: operates on active memory file, skips redirect files
- `commands/init.md`: Step 1a wizard question for memoryFiles selection
- `commands/status.md`: shows active memory file and all instances found in project
- `commands/sync.md`: filter step excludes files per memoryFiles config

## Test plan

- [ ] 246 tests pass (`uv run pytest tests/ -v`)
- [ ] `uv run ruff check .` - clean
- [ ] `uv run ruff format --check .` - clean
- [ ] `uv run mypy scripts/` - no issues
- [ ] Manual smoke: set `"memoryFiles": ["CLAUDE.md", "AGENTS.md"]`, edit a source file - confirm neither memory file appears in dirty-files
- [ ] Manual smoke: trigger SubagentStop with both files modified - confirm both committed in one commit